### PR TITLE
Added example for PFXImport - Fixes #213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CertificateDsc
   - Automatically publish documentation to GitHub Wiki - Fixes [Issue #235](https://github.com/dsccommunity/CertificateDsc/issues/235).
 
+### Added
+
+- PfxImport:
+  - Added example showing importing private key using `PsDscRunAsCredential`
+    to specify an administrator account - Fixes [Issue #213](https://github.com/dsccommunity/CertificateDsc/issues/213).
 
 ## [4.7.0.0] - 2019-06-26
 

--- a/source/DSCResources/DSC_PfxImport/README.md
+++ b/source/DSCResources/DSC_PfxImport/README.md
@@ -10,6 +10,12 @@ use a local or domain administrator credential to import certificates with a
 private key. To do this, set the `PsDscRunAsCredential` parameter with this
 resource to the credential of a local or domain administrator for this machine.
 
+If you still have problems importing the PFX into the Local Machine store
+please check the account specified in `PsDscRunAsCredential` has permissions
+to `$env:SystemDrive:\Documents and Settings\All Users\Application Data\Microsoft\Crypto\RSA\MachineKeys`.
+See [this page](https://docs.microsoft.com/en-us/troubleshoot/iis/cannot-import-ssl-pfx-local-certificate)
+for more information.
+
 ## Requirements
 
 - Target machine must be running Windows Server 2008 R2 or later.

--- a/source/DSCResources/DSC_PfxImport/README.md
+++ b/source/DSCResources/DSC_PfxImport/README.md
@@ -3,6 +3,13 @@
 The resource is used to import a PFX certificate into a Windows certificate
 store.
 
+## Credentials for Importing a Private Key
+
+Depending on your operating system and domain configuration, you may need to
+use a local or domain administrator credential to import certificates with a
+private key. To do this, set the `PsDscRunAsCredential` parameter with this
+resource to the credential of a local or domain administrator for this machine.
+
 ## Requirements
 
 - Target machine must be running Windows Server 2008 R2 or later.

--- a/source/Examples/Resources/PfxImport/5-PfxImport_InstallPFXAdministrator_Config.ps1
+++ b/source/Examples/Resources/PfxImport/5-PfxImport_InstallPFXAdministrator_Config.ps1
@@ -22,7 +22,7 @@
         Import a PFX into the 'Root' Local Machine certificate store using
         an administrator credential.
 #>
-Configuration PfxImport_InstallPFX_Config
+Configuration PfxImport_InstallPFXAdministrator_Config
 {
     param
     (

--- a/source/Examples/Resources/PfxImport/5-PfxImport_InstallPFXAdministrator_Config.ps1
+++ b/source/Examples/Resources/PfxImport/5-PfxImport_InstallPFXAdministrator_Config.ps1
@@ -1,0 +1,54 @@
+<#PSScriptInfo
+.VERSION 1.0.0
+.GUID dca596de-c24c-4600-bca8-9897d60c41c3
+.AUTHOR DSC Community
+.COMPANYNAME DSC Community
+.COPYRIGHT Copyright the DSC Community contributors. All rights reserved.
+.TAGS DSCConfiguration
+.LICENSEURI https://github.com/dsccommunity/CertificateDsc/blob/master/LICENSE
+.PROJECTURI https://github.com/dsccommunity/CertificateDsc
+.ICONURI
+.EXTERNALMODULEDEPENDENCIES
+.REQUIREDSCRIPTS
+.EXTERNALSCRIPTDEPENDENCIES
+.RELEASENOTES First version.
+.PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
+#>
+
+#Requires -Modules CertificateDsc
+
+<#
+    .DESCRIPTION
+        Import a PFX into the 'Root' Local Machine certificate store using
+        an administrator credential.
+#>
+Configuration PfxImport_InstallPFX_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.Management.Automation.PSCredential]
+        $AdminCredential
+    )
+
+    Import-DscResource -ModuleName CertificateDsc
+
+    Node localhost
+    {
+        PfxImport CompanyCert
+        {
+            Thumbprint           = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
+            Path                 = '\\Server\Share\Certificates\CompanyCert.pfx'
+            Location             = 'LocalMachine'
+            Store                = 'Root'
+            Credential           = $Credential
+            PsDscRunAsCredential = $AdminCredential
+        }
+    }
+}

--- a/source/Examples/Resources/PfxImport/5-PfxImport_InstallPFXAdministrator_Config.ps1
+++ b/source/Examples/Resources/PfxImport/5-PfxImport_InstallPFXAdministrator_Config.ps1
@@ -20,7 +20,11 @@
 <#
     .DESCRIPTION
         Import a PFX into the 'Root' Local Machine certificate store using
-        an administrator credential.
+        an administrator credential. The password in the Credential parameter
+        is used to decrypt the PFX file and the PsDscRunAsCredential is the
+        account that is used to import the certificate and private key into
+        Local Machine store. The PsDscRunAsCredential must have permission
+        to import the certificate and private key.
 #>
 Configuration PfxImport_InstallPFXAdministrator_Config
 {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR just adds a new example showing how to use PsDscRunAsCredential to import a certificate with a private key.

#### This Pull Request (PR) fixes the following issues

- Fixes #213

#### Task list

- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing if you have time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/certificatedsc/238)
<!-- Reviewable:end -->
