### PR TITLE
CertificateDsc: Add content parameter to ImportPFX and ImportCertificate resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PfxImport:
+  - Added Base64Content parameter to specify the content of a PFX file that can be included in the configuration MOF.
+
+- CertificateImport:
+  - Added Base64Content parameter to specify the content of a certificate file that can be included in the configuration MOF.
+
 ## [5.0.0] - 2020-10-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - PfxImport:
-  - Added Base64Content parameter to specify the content of a PFX file that can be included in the configuration MOF.
-
+  - Added Base64Content parameter to specify the content of a PFX file that can be included in the configuration MOF - Fixes [Issue #241](https://github.com/dsccommunity/CertificateDsc/issues/241).
 - CertificateImport:
-  - Added Base64Content parameter to specify the content of a certificate file that can be included in the configuration MOF.
+  - Added Base64Content parameter to specify the content of a certificate file that can be included in the configuration MOF - Fixes [Issue #241](https://github.com/dsccommunity/CertificateDsc/issues/241).
 
 ### Changed
 
 - Renamed `master` branch to `main` - Fixes [Issue #237](https://github.com/dsccommunity/CertificateDsc/issues/237).
-
 
 ## [5.0.0] - 2020-10-16
 

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
@@ -103,6 +103,7 @@ function Get-TargetResource
     return @{
         Thumbprint   = $Thumbprint
         Path         = $Path
+        Content      = $Content
         Location     = $Location
         Store        = $Store
         Ensure       = $Ensure

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
@@ -24,7 +24,7 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     This parameter is ignored.
 
     .PARAMETER Content
-    The content of the CER file you want to import.
+    The base64 encoded content of the CER file you want to import.
     This parameter is ignored.
 
     .PARAMETER Location
@@ -122,7 +122,7 @@ function Get-TargetResource
     The path to the CER file you want to import.
 
     .PARAMETER Content
-    The content of the CER file you want to import.
+    The base64 encoded content of the CER file you want to import.
 
     .PARAMETER Location
     The Windows Certificate Store Location to import the certificate to.
@@ -216,7 +216,7 @@ function Test-TargetResource
     The path to the CER file you want to import.
 
     .PARAMETER Content
-    The content of the CER file you want to import.
+    The base64 encoded content of the CER file you want to import.
 
     .PARAMETER Location
     The Windows Certificate Store Location to import the certificate to.

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
@@ -52,12 +52,11 @@ function Get-TargetResource
         [System.String]
         $Thumbprint,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Path,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $Content,
 
@@ -147,12 +146,11 @@ function Test-TargetResource
         [System.String]
         $Thumbprint,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Path,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $Content,
 
@@ -240,12 +238,11 @@ function Set-TargetResource
         [System.String]
         $Thumbprint,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Path,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $Content,
 
@@ -274,6 +271,8 @@ function Set-TargetResource
             "$($MyInvocation.MyCommand): "
             $($script:localizedData.SettingCertificateStatusMessage -f $Thumbprint, $Location, $Store)
         ) -join '' )
+
+    Assert-ResourceProperty @PSBoundParameters
 
     if ($Ensure -ieq 'Present')
     {
@@ -351,5 +350,38 @@ function Set-TargetResource
             -Store $Store
     }
 }  # end function Test-TargetResource
+
+function Assert-ResourceProperty
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Path,
+
+        [Parameter()]
+        [System.String]
+        $Content,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter(ValueFromRemainingArguments)]
+        $RemainingParameters
+    )
+
+    if ($Ensure -ieq 'Present')
+    {
+        if ([string]::IsNullOrWhiteSpace($Content) -band [string]::IsNullOrWhiteSpace($Path))
+        {
+            New-InvalidArgumentException `
+                -Message ($script:localizedData.ContentAndPathParametersAreNull) `
+                -ArgumentName 'Path|Content'
+        }
+    }
+}
 
 Export-ModuleMember -Function *-TargetResource

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
@@ -23,6 +23,10 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     The path to the CER file you want to import.
     This parameter is ignored.
 
+    .PARAMETER Content
+    The content of the CER file you want to import.
+    This parameter is ignored.
+
     .PARAMETER Location
     The Windows Certificate Store Location to import the certificate to.
 
@@ -51,6 +55,11 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Path,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Content,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('CurrentUser', 'LocalMachine')]
@@ -112,6 +121,9 @@ function Get-TargetResource
     .PARAMETER Path
     The path to the CER file you want to import.
 
+    .PARAMETER Content
+    The content of the CER file you want to import.
+
     .PARAMETER Location
     The Windows Certificate Store Location to import the certificate to.
 
@@ -138,6 +150,11 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Path,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Content,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('CurrentUser', 'LocalMachine')]
@@ -198,6 +215,9 @@ function Test-TargetResource
     .PARAMETER Path
     The path to the CER file you want to import.
 
+    .PARAMETER Content
+    The content of the CER file you want to import.
+
     .PARAMETER Location
     The Windows Certificate Store Location to import the certificate to.
 
@@ -223,6 +243,11 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Path,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Content,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('CurrentUser', 'LocalMachine')]
@@ -262,6 +287,11 @@ function Set-TargetResource
                     $($script:localizedData.ImportingCertficateMessage -f $Path, $Location, $Store)
                 ) -join '' )
 
+            if ($PSBoundParameters.ContainsKey('Content'))
+            {
+                Set-Base64Content -Value $Content -Path $Path -ErrorAction Stop
+            }
+
             # Check that the certificate file exists before trying to import
             if (-not (Test-Path -Path $Path))
             {
@@ -287,6 +317,11 @@ function Set-TargetResource
                 https://github.com/dsccommunity/CertificateDsc/issues/161
             #>
             Import-CertificateEx @importCertificateParameters
+
+            if ($PSBoundParameters.ContainsKey('Content'))
+            {
+                Remove-Item -Path $Path -Force
+            }
         }
 
         if ($PSBoundParameters.ContainsKey('FriendlyName') `

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
@@ -181,6 +181,8 @@ function Test-TargetResource
             $($script:localizedData.TestingCertificateStatusMessage -f $Thumbprint, $Location, $Store)
         ) -join '' )
 
+    Assert-ResourceProperty @PSBoundParameters
+
     $currentState = Get-TargetResource @PSBoundParameters
 
     if ($Ensure -ne $currentState.Ensure)
@@ -350,7 +352,7 @@ function Set-TargetResource
             -Location $Location `
             -Store $Store
     }
-}  # end function Test-TargetResource
+}  # end function Set-TargetResource
 
 function Assert-ResourceProperty
 {
@@ -376,10 +378,17 @@ function Assert-ResourceProperty
 
     if ($Ensure -ieq 'Present')
     {
-        if ([string]::IsNullOrWhiteSpace($Content) -band [string]::IsNullOrWhiteSpace($Path))
+        if ([System.String]::IsNullOrWhiteSpace($Content) -band [System.String]::IsNullOrWhiteSpace($Path))
         {
             New-InvalidArgumentException `
                 -Message ($script:localizedData.ContentAndPathParametersAreNull) `
+                -ArgumentName 'Path|Content'
+        }
+
+        if ($PSBoundParameters.ContainsKey('Content') -and $PSBoundParameters.ContainsKey('Path'))
+        {
+            New-InvalidArgumentException `
+                -Message ($script:localizedData.ContentAndPathParametersAreSet) `
                 -ArgumentName 'Path|Content'
         }
     }

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.psm1
@@ -24,8 +24,8 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
         This parameter is ignored.
 
     .PARAMETER Content
-    The base64 encoded content of the CER file you want to import.
-    This parameter is ignored.
+        The base64 encoded content of the CER file you want to import.
+        This parameter is ignored.
 
     .PARAMETER Location
         The Windows Certificate Store Location to import the certificate to.
@@ -122,7 +122,7 @@ function Get-TargetResource
         The path to the CER file you want to import.
 
     .PARAMETER Content
-    The base64 encoded content of the CER file you want to import.
+        The base64 encoded content of the CER file you want to import.
 
     .PARAMETER Location
         The Windows Certificate Store Location to import the certificate to.
@@ -215,7 +215,7 @@ function Test-TargetResource
         The path to the CER file you want to import.
 
     .PARAMETER Content
-    The base64 encoded content of the CER file you want to import.
+        The base64 encoded content of the CER file you want to import.
 
     .PARAMETER Location
         The Windows Certificate Store Location to import the certificate to.

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.schema.mof
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.schema.mof
@@ -3,7 +3,7 @@ class DSC_CertificateImport : OMI_BaseResource
 {
     [Key,Description("The thumbprint (unique identifier) of the certificate you're importing.")] string Thumbprint;
     [Required,Description("The path to the CER file you want to import.")] string Path;
-    [Write,Description("The content of the CER file you want to import.")] string Content;
+    [Write,Description("The base64 encoded content of the CER file you want to import.")] string Content;
     [Key,Description("The Windows Certificate Store Location to import the certificate to."),ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
     [Key,Description("The Windows Certificate Store Name to import the certificate to.")] string Store;
     [Write,Description("Specifies whether the certificate should be present or absent."),ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.schema.mof
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.schema.mof
@@ -2,7 +2,7 @@
 class DSC_CertificateImport : OMI_BaseResource
 {
     [Key,Description("The thumbprint (unique identifier) of the certificate you're importing.")] string Thumbprint;
-    [Required,Description("The path to the CER file you want to import.")] string Path;
+    [Write,Description("The path to the CER file you want to import.")] string Path;
     [Write,Description("The base64 encoded content of the CER file you want to import.")] string Content;
     [Key,Description("The Windows Certificate Store Location to import the certificate to."),ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
     [Key,Description("The Windows Certificate Store Name to import the certificate to.")] string Store;

--- a/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.schema.mof
+++ b/source/DSCResources/DSC_CertificateImport/DSC_CertificateImport.schema.mof
@@ -3,6 +3,7 @@ class DSC_CertificateImport : OMI_BaseResource
 {
     [Key,Description("The thumbprint (unique identifier) of the certificate you're importing.")] string Thumbprint;
     [Required,Description("The path to the CER file you want to import.")] string Path;
+    [Write,Description("The content of the CER file you want to import.")] string Content;
     [Key,Description("The Windows Certificate Store Location to import the certificate to."),ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
     [Key,Description("The Windows Certificate Store Name to import the certificate to.")] string Store;
     [Write,Description("Specifies whether the certificate should be present or absent."),ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;

--- a/source/DSCResources/DSC_CertificateImport/en-US/DSC_CertificateImport.strings.psd1
+++ b/source/DSCResources/DSC_CertificateImport/en-US/DSC_CertificateImport.strings.psd1
@@ -8,4 +8,5 @@ ConvertFrom-StringData @'
     SettingCertficateFriendlyNameMessage = Setting Certificate '{0}' from '{1}' store '{2}' friendly name to '{3}'. (CI0007)
     CertificateFriendlyNameMismatchMessage = The Fiendly Name of Certificate '{0}' from '{1}' store '{2}' is set to '{3}', but should be '{4}'. (CI0008)
     ContentAndPathParametersAreNull = A non-null or non-empty value must be supplied for the Path or Content parameter. (CI0009)
+    ContentAndPathParametersAreSet = The use of both Path and Content parameters is not supported. (CI0010)
 '@

--- a/source/DSCResources/DSC_CertificateImport/en-US/DSC_CertificateImport.strings.psd1
+++ b/source/DSCResources/DSC_CertificateImport/en-US/DSC_CertificateImport.strings.psd1
@@ -7,4 +7,5 @@ ConvertFrom-StringData @'
     CertificateFileNotFoundError = Certificate Pfx file '{0}' not found. (CI0006)
     SettingCertficateFriendlyNameMessage = Setting Certificate '{0}' from '{1}' store '{2}' friendly name to '{3}'. (CI0007)
     CertificateFriendlyNameMismatchMessage = The Fiendly Name of Certificate '{0}' from '{1}' store '{2}' is set to '{3}', but should be '{4}'. (CI0008)
+    ContentAndPathParametersAreNull = A non-null or non-empty value must be supplied for the Path or Content parameter. (CI0009)
 '@

--- a/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
+++ b/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
@@ -244,6 +244,8 @@ function Test-TargetResource
             $($script:localizedData.TestingPfxStatusMessage -f $Thumbprint, $Location, $Store)
         ) -join '' )
 
+    Assert-ResourceProperty @PSBoundParameters
+
     $currentState = Get-TargetResource @PSBoundParameters
 
     if ($Ensure -ne $currentState.Ensure)
@@ -466,10 +468,17 @@ function Assert-ResourceProperty
 
     if ($Ensure -ieq 'Present')
     {
-        if ([string]::IsNullOrWhiteSpace($Content) -band [string]::IsNullOrWhiteSpace($Path))
+        if ([System.String]::IsNullOrWhiteSpace($Content) -band [System.String]::IsNullOrWhiteSpace($Path))
         {
             New-InvalidArgumentException `
                 -Message ($script:localizedData.ContentAndPathParametersAreNull) `
+                -ArgumentName 'Path|Content'
+        }
+
+        if ($PSBoundParameters.ContainsKey('Content') -and $PSBoundParameters.ContainsKey('Path'))
+        {
+            New-InvalidArgumentException `
+                -Message ($script:localizedData.ContentAndPathParametersAreSet) `
                 -ArgumentName 'Path|Content'
         }
     }

--- a/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
+++ b/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
@@ -24,8 +24,8 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
         This parameter is ignored.
 
     .PARAMETER Content
-    The base64 encoded content of the PFX file you want to import.
-    This parameter is ignored.
+        The base64 encoded content of the PFX file you want to import.
+        This parameter is ignored.
 
     .PARAMETER Location
         The Windows Certificate Store Location to import the PFX file to.
@@ -168,7 +168,7 @@ function Get-TargetResource
         The path to the PFX file you want to import.
 
     .PARAMETER Content
-    The base64 encoded content of the PFX file you want to import.
+        The base64 encoded content of the PFX file you want to import.
 
     .PARAMETER Location
         The Windows Certificate Store Location to import the PFX file to.
@@ -278,7 +278,7 @@ function Test-TargetResource
         The path to the PFX file you want to import.
 
     .PARAMETER Content
-    The base64 encoded content of the PFX file you want to import.
+        The base64 encoded content of the PFX file you want to import.
 
     .PARAMETER Location
         The Windows Certificate Store Location to import the PFX file to.

--- a/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
+++ b/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
@@ -24,7 +24,7 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     This parameter is ignored.
 
     .PARAMETER Content
-    The content of the PFX file you want to import.
+    The base64 encoded content of the PFX file you want to import.
     This parameter is ignored.
 
     .PARAMETER Location
@@ -167,7 +167,7 @@ function Get-TargetResource
     The path to the PFX file you want to import.
 
     .PARAMETER Content
-    The content of the PFX file you want to import.
+    The base64 encoded content of the PFX file you want to import.
 
     .PARAMETER Location
     The Windows Certificate Store Location to import the PFX file to.
@@ -277,7 +277,7 @@ function Test-TargetResource
     The path to the PFX file you want to import.
 
     .PARAMETER Content
-    The content of the PFX file you want to import.
+    The base64 encoded content of the PFX file you want to import.
 
     .PARAMETER Location
     The Windows Certificate Store Location to import the PFX file to.

--- a/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
+++ b/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
@@ -147,6 +147,7 @@ function Get-TargetResource
     return @{
         Thumbprint   = $Thumbprint
         Path         = $Path
+        Content      = $Content
         Location     = $Location
         Store        = $Store
         Exportable   = $Exportable

--- a/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
+++ b/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
@@ -352,6 +352,8 @@ function Set-TargetResource
             $($script:localizedData.SettingPfxStatusMessage -f $Thumbprint, $Location, $Store)
         ) -join '' )
 
+    Assert-ResourceProperty @PSBoundParameters
+
     if ($Ensure -ieq 'Present')
     {
         $currentState = Get-TargetResource @PSBoundParameters
@@ -438,5 +440,38 @@ function Set-TargetResource
             -Store $Store
     }
 } # end function Set-TargetResource
+
+function Assert-ResourceProperty
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Path,
+
+        [Parameter()]
+        [System.String]
+        $Content,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter(ValueFromRemainingArguments)]
+        $RemainingParameters
+    )
+
+    if ($Ensure -ieq 'Present')
+    {
+        if ([string]::IsNullOrWhiteSpace($Content) -band [string]::IsNullOrWhiteSpace($Path))
+        {
+            New-InvalidArgumentException `
+                -Message ($script:localizedData.ContentAndPathParametersAreNull) `
+                -ArgumentName 'Path|Content'
+        }
+    }
+}
 
 Export-ModuleMember -Function *-TargetResource

--- a/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
+++ b/source/DSCResources/DSC_PfxImport/DSC_PfxImport.psm1
@@ -23,6 +23,10 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     The path to the PFX file you want to import.
     This parameter is ignored.
 
+    .PARAMETER Content
+    The content of the PFX file you want to import.
+    This parameter is ignored.
+
     .PARAMETER Location
     The Windows Certificate Store Location to import the PFX file to.
 
@@ -61,6 +65,11 @@ function Get-TargetResource
         [Parameter()]
         [System.String]
         $Path,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Content,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('CurrentUser', 'LocalMachine')]
@@ -157,6 +166,9 @@ function Get-TargetResource
     .PARAMETER Path
     The path to the PFX file you want to import.
 
+    .PARAMETER Content
+    The content of the PFX file you want to import.
+
     .PARAMETER Location
     The Windows Certificate Store Location to import the PFX file to.
 
@@ -191,6 +203,11 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $Path,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Content,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('CurrentUser', 'LocalMachine')]
@@ -259,6 +276,9 @@ function Test-TargetResource
     .PARAMETER Path
     The path to the PFX file you want to import.
 
+    .PARAMETER Content
+    The content of the PFX file you want to import.
+
     .PARAMETER Location
     The Windows Certificate Store Location to import the PFX file to.
 
@@ -292,6 +312,11 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $Path,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Content,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('CurrentUser', 'LocalMachine')]
@@ -339,6 +364,11 @@ function Set-TargetResource
                     $($script:localizedData.ImportingPfxMessage -f $Path, $Location, $Store)
                 ) -join '' )
 
+            if ($PSBoundParameters.ContainsKey('Content'))
+            {
+                Set-Base64Content -Value $Content -Path $Path -ErrorAction Stop
+            }
+
             # Check that the certificate PFX file exists before trying to import
             if (-not (Test-Path -Path $Path))
             {
@@ -373,6 +403,11 @@ function Set-TargetResource
             else
             {
                 Import-PfxCertificateEx @importPfxCertificateParameters
+            }
+
+            if ($PSBoundParameters.ContainsKey('Content'))
+            {
+                Remove-Item -Path $Path -Force
             }
         }
 

--- a/source/DSCResources/DSC_PfxImport/DSC_PfxImport.schema.mof
+++ b/source/DSCResources/DSC_PfxImport/DSC_PfxImport.schema.mof
@@ -3,6 +3,7 @@ class DSC_PfxImport : OMI_BaseResource
 {
     [Key,Description("The thumbprint (unique identifier) of the PFX file you're importing.")] string Thumbprint;
     [Write,Description("The path to the PFX file you want to import.")] string Path;
+    [Write,Description("The content of the PFX file you want to import.")] string Content;
     [Key,Description("The Windows Certificate Store Location to import the PFX file to."),ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
     [Key,Description("The Windows Certificate Store Name to import the PFX file to.")] string Store;
     [write,Description("Determines whether the private key is exportable from the machine after it has been imported")] boolean Exportable;

--- a/source/DSCResources/DSC_PfxImport/DSC_PfxImport.schema.mof
+++ b/source/DSCResources/DSC_PfxImport/DSC_PfxImport.schema.mof
@@ -3,7 +3,7 @@ class DSC_PfxImport : OMI_BaseResource
 {
     [Key,Description("The thumbprint (unique identifier) of the PFX file you're importing.")] string Thumbprint;
     [Write,Description("The path to the PFX file you want to import.")] string Path;
-    [Write,Description("The content of the PFX file you want to import.")] string Content;
+    [Write,Description("The base64 encoded content of the PFX file you want to import.")] string Content;
     [Key,Description("The Windows Certificate Store Location to import the PFX file to."),ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
     [Key,Description("The Windows Certificate Store Name to import the PFX file to.")] string Store;
     [write,Description("Determines whether the private key is exportable from the machine after it has been imported")] boolean Exportable;

--- a/source/DSCResources/DSC_PfxImport/en-US/DSC_PfxImport.strings.psd1
+++ b/source/DSCResources/DSC_PfxImport/en-US/DSC_PfxImport.strings.psd1
@@ -11,4 +11,5 @@ ConvertFrom-StringData @'
     SettingCertficateFriendlyNameMessage = Setting Certificate '{0}' from '{1}' store '{2}' friendly name to '{3}'. (PI0011)
     CertificateFriendlyNameMismatchMessage = The Fiendly Name of Certificate '{0}' from '{1}' store '{2}' is set to '{3}', but should be '{4}'. (PI0012)
     ContentAndPathParametersAreNull = A non-null or non-empty value must be supplied for the Path or Content parameter. (CI0013)
+    ContentAndPathParametersAreSet = The use of both Path and Content parameters is not supported. (CI0014)
 '@

--- a/source/DSCResources/DSC_PfxImport/en-US/DSC_PfxImport.strings.psd1
+++ b/source/DSCResources/DSC_PfxImport/en-US/DSC_PfxImport.strings.psd1
@@ -10,4 +10,5 @@ ConvertFrom-StringData @'
     CertificatePfxFileNotFoundError = Certificate Pfx file '{0}' not found. (PI0010)
     SettingCertficateFriendlyNameMessage = Setting Certificate '{0}' from '{1}' store '{2}' friendly name to '{3}'. (PI0011)
     CertificateFriendlyNameMismatchMessage = The Fiendly Name of Certificate '{0}' from '{1}' store '{2}' is set to '{3}', but should be '{4}'. (PI0012)
+    ContentAndPathParametersAreNull = A non-null or non-empty value must be supplied for the Path or Content parameter. (CI0013)
 '@

--- a/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
+++ b/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 .VERSION 1.0.0
-.GUID f35aa0ac-1b22-4309-89aa-05618419e7b9
+.GUID 48a20a89-efc4-4ea7-8da5-e9f740aa89fe
 .AUTHOR DSC Community
 .COMPANYNAME DSC Community
 .COPYRIGHT Copyright the DSC Community contributors. All rights reserved.

--- a/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
+++ b/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
@@ -17,8 +17,14 @@
 
 #Requires -module CertificateDsc
 
-$contentByte = Get-Content -Path D:\MyTrustedRoot.cer -Encoding Byte
-$contentBase64 = ([System.Convert]::ToBase64String($contentByte))
+<#
+    .DESCRIPTION
+        Create mock base64 value
+    example for converting an existing file:
+    $contentByte = Get-Content -Path D:\MyTrustedRoot.cer -Encoding Byte
+    $contentBase64 = ([System.Convert]::ToBase64String($contentByte))
+#>
+$contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
 
 <#
     .DESCRIPTION

--- a/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
+++ b/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
@@ -21,8 +21,7 @@
     .DESCRIPTION
         Create mock base64 value
     example for converting an existing file:
-    $contentByte = Get-Content -Path D:\MyTrustedRoot.cer -Encoding Byte
-    $contentBase64 = ([System.Convert]::ToBase64String($contentByte))
+    $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
 #>
 $contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
 

--- a/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
+++ b/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
@@ -27,10 +27,9 @@ Configuration CertificateImport_WithContent_Config
     Import-DscResource -ModuleName CertificateDsc
 
     <#
-        .DESCRIPTION
-            Create mock base64 value
-            example for converting an existing file:
-            $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
+        Create mock base64 value
+        example for converting an existing file:
+        $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
     #>
     $contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
 

--- a/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
+++ b/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
@@ -19,20 +19,20 @@
 
 <#
     .DESCRIPTION
-        Create mock base64 value
-    example for converting an existing file:
-    $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
-#>
-$contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
-
-<#
-    .DESCRIPTION
         Import public key certificate into Trusted Root store from
         a provided base64 encoded string.
 #>
 Configuration CertificateImport_WithContent_Config
 {
     Import-DscResource -ModuleName CertificateDsc
+
+    <#
+        .DESCRIPTION
+            Create mock base64 value
+            example for converting an existing file:
+            $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
+    #>
+    $contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
 
     Node localhost
     {
@@ -41,7 +41,6 @@ Configuration CertificateImport_WithContent_Config
             Thumbprint   = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
             Location     = 'LocalMachine'
             Store        = 'Root'
-            Path         = 'C:\Windows\Temp\MyTrustedRoot.cer'
             Content      = $contentBase64
         }
     }

--- a/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
+++ b/source/Examples/Resources/CertificateImport/3-CertificateImport_WithContent_Config.ps1
@@ -1,0 +1,43 @@
+<#PSScriptInfo
+.VERSION 1.0.0
+.GUID f35aa0ac-1b22-4309-89aa-05618419e7b9
+.AUTHOR DSC Community
+.COMPANYNAME DSC Community
+.COPYRIGHT Copyright the DSC Community contributors. All rights reserved.
+.TAGS DSCConfiguration
+.LICENSEURI https://github.com/dsccommunity/CertificateDsc/blob/master/LICENSE
+.PROJECTURI https://github.com/dsccommunity/CertificateDsc
+.ICONURI
+.EXTERNALMODULEDEPENDENCIES
+.REQUIREDSCRIPTS
+.EXTERNALSCRIPTDEPENDENCIES
+.RELEASENOTES First version.
+.PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
+#>
+
+#Requires -module CertificateDsc
+
+$contentByte = Get-Content -Path D:\MyTrustedRoot.cer -Encoding Byte
+$contentBase64 = ([System.Convert]::ToBase64String($contentByte))
+
+<#
+    .DESCRIPTION
+        Import public key certificate into Trusted Root store from
+        a provided base64 encoded string.
+#>
+Configuration CertificateImport_WithContent_Config
+{
+    Import-DscResource -ModuleName CertificateDsc
+
+    Node localhost
+    {
+        CertificateImport MyTrustedRoot
+        {
+            Thumbprint   = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
+            Location     = 'LocalMachine'
+            Store        = 'Root'
+            Path         = 'C:\Windows\Temp\MyTrustedRoot.cer'
+            Content      = $contentBase64
+        }
+    }
+}

--- a/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
+++ b/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
@@ -21,8 +21,7 @@
     .DESCRIPTION
         Create mock base64 value
     example for converting an existing file:
-    $contentByte = Get-Content -Path D:\CompanyCert.pfx -Encoding Byte
-    $contentBase64 = ([System.Convert]::ToBase64String($contentByte))
+    $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
 #>
 $contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
 

--- a/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
+++ b/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
@@ -19,14 +19,6 @@
 
 <#
     .DESCRIPTION
-        Create mock base64 value
-    example for converting an existing file:
-    $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
-#>
-$contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
-
-<#
-    .DESCRIPTION
         Import a PFX into the 'My' Local Machine certificate store.
 #>
 Configuration PfxImport_InstallPFXFromContent_Config
@@ -41,12 +33,19 @@ Configuration PfxImport_InstallPFXFromContent_Config
 
     Import-DscResource -ModuleName CertificateDsc
 
+    <#
+        .DESCRIPTION
+            Create mock base64 value
+            example for converting an existing file:
+            $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
+    #>
+    $contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
+
     Node localhost
     {
         PfxImport CompanyCert
         {
             Thumbprint = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
-            Path       = 'C:\Windows\Temp\CompanyCert.pfx'
             Content    = $contentBase64
             Location   = 'LocalMachine'
             Store      = 'My'

--- a/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
+++ b/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
@@ -17,8 +17,14 @@
 
 #Requires -Modules CertificateDsc
 
-$contentByte = Get-Content -Path D:\CompanyCert.pfx -Encoding Byte
-$contentBase64 = ([System.Convert]::ToBase64String($contentByte))
+<#
+    .DESCRIPTION
+        Create mock base64 value
+    example for converting an existing file:
+    $contentByte = Get-Content -Path D:\CompanyCert.pfx -Encoding Byte
+    $contentBase64 = ([System.Convert]::ToBase64String($contentByte))
+#>
+$contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
 
 <#
     .DESCRIPTION

--- a/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
+++ b/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 .VERSION 1.0.0
-.GUID a93bd794-e0c1-45fb-a988-c637257d4b35
+.GUID fa81342d-b96d-401b-8a18-c96bebd4aff6
 .AUTHOR DSC Community
 .COMPANYNAME DSC Community
 .COPYRIGHT Copyright the DSC Community contributors. All rights reserved.

--- a/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
+++ b/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
@@ -1,0 +1,51 @@
+<#PSScriptInfo
+.VERSION 1.0.0
+.GUID a93bd794-e0c1-45fb-a988-c637257d4b35
+.AUTHOR DSC Community
+.COMPANYNAME DSC Community
+.COPYRIGHT Copyright the DSC Community contributors. All rights reserved.
+.TAGS DSCConfiguration
+.LICENSEURI https://github.com/dsccommunity/CertificateDsc/blob/master/LICENSE
+.PROJECTURI https://github.com/dsccommunity/CertificateDsc
+.ICONURI
+.EXTERNALMODULEDEPENDENCIES
+.REQUIREDSCRIPTS
+.EXTERNALSCRIPTDEPENDENCIES
+.RELEASENOTES First version.
+.PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
+#>
+
+#Requires -Modules CertificateDsc
+
+$contentByte = Get-Content -Path D:\CompanyCert.pfx -Encoding Byte
+$contentBase64 = ([System.Convert]::ToBase64String($contentByte))
+
+<#
+    .DESCRIPTION
+        Import a PFX into the 'My' Local Machine certificate store.
+#>
+Configuration PfxImport_InstallPFXFromContent_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential
+    )
+
+    Import-DscResource -ModuleName CertificateDsc
+
+    Node localhost
+    {
+        PfxImport CompanyCert
+        {
+            Thumbprint = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
+            Path       = 'C:\Windows\Temp\CompanyCert.pfx'
+            Content    = $contentBase64
+            Location   = 'LocalMachine'
+            Store      = 'My'
+            Credential = $Credential
+        }
+    }
+}

--- a/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
+++ b/source/Examples/Resources/PfxImport/6-PfxImport_InstallPFXFromContent_Config.ps1
@@ -34,10 +34,9 @@ Configuration PfxImport_InstallPFXFromContent_Config
     Import-DscResource -ModuleName CertificateDsc
 
     <#
-        .DESCRIPTION
-            Create mock base64 value
-            example for converting an existing file:
-            $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
+        Create mock base64 value
+        example for converting an existing file:
+        $contentBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificateFilePath))
     #>
     $contentBase64 = [System.Convert]::ToBase64String(@(00, 00, 00))
 

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -1212,6 +1212,38 @@ function Set-CertificateFriendlyNameInCertificateStore
     }
 }
 
+<#
+    .SYNOPSIS
+    This function sets the content of a specified file with the decoded value
+    from a base64 encoded string.
+
+    .PARAMETER Path
+    The path to where the content is witten.
+
+    .PARAMETER Value
+    The base64 endoed string that will be decoded.
+#>
+function Set-Base64Content
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Value
+    )
+
+    $byteValue = [Convert]::FromBase64String($Value)
+    [io.file]::WriteAllBytes($Path, $byteValue)
+}
+
+
 Export-ModuleMember -Function @(
     'Test-CertificatePath',
     'Test-Thumbprint',
@@ -1235,4 +1267,5 @@ Export-ModuleMember -Function @(
     'Get-CertificateFromCertificateStore',
     'Remove-CertificateFromCertificateStore',
     'Set-CertificateFriendlyNameInCertificateStore'
+    'Set-Base64Content'
 )

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -994,11 +994,11 @@ function Import-PfxCertificateEx
 
     if ($PSCmdlet.ParameterSetName -eq 'Path')
     {
-        $certificateData = $FilePath
+        $importDataValue = $FilePath
     }
     else
     {
-        $certificateData = [Convert]::FromBase64String($Base64Content)
+        $importDataValue = [Convert]::FromBase64String($Base64Content)
     }
 
     if ($Exportable)
@@ -1008,11 +1008,11 @@ function Import-PfxCertificateEx
 
     if ($Password)
     {
-        $cert.Import($certificateData, $Password, $flags)
+        $cert.Import($importDataValue, $Password, $flags)
     }
     else
     {
-        $cert.Import($certificateData, $flags)
+        $cert.Import($importDataValue, $flags)
     }
 
     $certStore = New-Object `

--- a/tests/Integration/DSC_CertificateImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_CertificateImport.Integration.Tests.ps1
@@ -127,7 +127,6 @@ try
                         Location     = 'LocalMachine'
                         Store        = 'My'
                         Ensure       = 'Present'
-                        Path         = $certificatePath
                         Content      = $testBase64Content
                         FriendlyName = $certificateFriendlyName
                     }

--- a/tests/Integration/DSC_CertificateImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_CertificateImport.Integration.Tests.ps1
@@ -135,7 +135,7 @@ try
 
             It 'Should compile the MOF without throwing an exception' {
                 {
-                    & "$($script:DSCResourceName)_Config" `
+                    & "$($script:DSCResourceName)_Config_WithContent" `
                         -OutputPath $TestDrive `
                         -ConfigurationData $configData
                 } | Should -Not -Throw

--- a/tests/Integration/DSC_CertificateImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_CertificateImport.Integration.Tests.ps1
@@ -45,8 +45,8 @@ try
                 -Path $certificate.PSPath `
                 -Force
             $certificateFriendlyName = 'Test Certificate Friendly Name'
-            $contentByte = Get-Content -Path $certificatePath -Encoding Byte
-            $testBase64Content = [System.Convert]::ToBase64String($contentByte)
+
+            $testBase64Content = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certificatePath))
         }
 
         AfterAll {

--- a/tests/Integration/DSC_CertificateImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_CertificateImport.Integration.Tests.ps1
@@ -51,14 +51,21 @@ try
 
         AfterAll {
             # Cleanup
-            $null = Remove-Item `
-                -Path $certificatePath `
-                -Force `
-                -ErrorAction SilentlyContinue
-            $null = Remove-Item `
-                -Path $certificate.PSPath `
-                -Force `
-                -ErrorAction SilentlyContinue
+            if ($null -ne $certificatePath)
+            {
+                $null = Remove-Item `
+                    -Path $certificatePath `
+                    -Force `
+                    -ErrorAction SilentlyContinue
+            }
+
+            if ($null -ne $certificate.PSPath)
+            {
+                $null = Remove-Item `
+                    -Path $certificate.PSPath `
+                    -Force `
+                    -ErrorAction SilentlyContinue
+            }
         }
 
         Context 'Import certificate file' {

--- a/tests/Integration/DSC_CertificateImport.config.ps1
+++ b/tests/Integration/DSC_CertificateImport.config.ps1
@@ -12,3 +12,18 @@ Configuration DSC_CertificateImport_Config {
         }
     }
 }
+
+Configuration DSC_CertificateImport_Config_WithContent {
+    Import-DscResource -ModuleName CertificateDsc
+
+    node localhost {
+        CertificateImport Integration_Test {
+            Thumbprint   = $Node.Thumbprint
+            Content      = $Node.Content
+            Location     = $Node.Location
+            Store        = $Node.Store
+            Ensure       = $Node.Ensure
+            FriendlyName = $Node.FriendlyName
+        }
+    }
+}

--- a/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
@@ -60,7 +60,7 @@ try
                 -FilePath $pfxPath `
                 -Password $testCredential.Password
 
-            $contentByte = Get-Content -Path D:\ContentStore\Certificates\RpsRoot.cer -Encoding Byte
+            $contentByte = Get-Content -Path $pfxPath -Encoding Byte
             $testBase64Content = [System.Convert]::ToBase64String($contentByte)
 
             $null = Export-Certificate `
@@ -257,7 +257,7 @@ try
         Context 'When certificate content has not been imported yet' {
             It 'Should compile the MOF without throwing an exception' {
                 {
-                    & "$($script:DSCResourceName)_Add_Config" `
+                    & "$($script:DSCResourceName)_Add_Config_With_Content" `
                         -OutputPath $TestDrive `
                         -ConfigurationData $configDataForAddWithContent
                 } | Should -Not -Throw

--- a/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
@@ -41,13 +41,9 @@ try
                 -Path $env:Temp `
                 -ChildPath "PfxImport-$($certificate.Thumbprint).pfx"
 
-            $pfxPathContentOutput1 = Join-Path `
+            $pfxPathContentOutput = Join-Path `
                 -Path $env:Temp `
                 -ChildPath "PfxContentImport1-$($certificate.Thumbprint).pfx"
-
-            $pfxPathContentOutput2 = Join-Path `
-                -Path $env:Temp `
-                -ChildPath "PfxContentImport2-$($certificate.Thumbprint).pfx"
 
             $cerPath = Join-Path `
                 -Path $env:Temp `
@@ -64,8 +60,7 @@ try
                 -FilePath $pfxPath `
                 -Password $testCredential.Password
 
-            $contentByte = Get-Content -Path $pfxPath -Encoding Byte
-            $testBase64Content = [System.Convert]::ToBase64String($contentByte)
+            $testBase64Content = [Convert]::ToBase64String([IO.File]::ReadAllBytes($pfxPath))
 
             $null = Export-Certificate `
                 -Type CERT `
@@ -94,7 +89,7 @@ try
                 )
             }
 
-            $configDataForAddWithContent1 = @{
+            $configDataForAddWithContent = @{
                 AllNodes = @(
                     @{
                         NodeName                    = 'localhost'
@@ -102,24 +97,7 @@ try
                         Location                    = 'LocalMachine'
                         Store                       = 'My'
                         Ensure                      = 'Present'
-                        Path                        = $pfxPathContentOutput1
-                        Content                     = $testBase64Content
-                        Credential                  = $testCredential
-                        FriendlyName                = $certificateFriendlyName
-                        PSDscAllowPlainTextPassword = $true
-                    }
-                )
-            }
-
-            $configDataForAddWithContent2 = @{
-                AllNodes = @(
-                    @{
-                        NodeName                    = 'localhost'
-                        Thumbprint                  = $certificate.Thumbprint
-                        Location                    = 'LocalMachine'
-                        Store                       = 'My'
-                        Ensure                      = 'Present'
-                        Path                        = $pfxPathContentOutput2
+                        Path                        = $pfxPathContentOutput
                         Content                     = $testBase64Content
                         Credential                  = $testCredential
                         FriendlyName                = $certificateFriendlyName
@@ -280,7 +258,7 @@ try
                 {
                     & "$($script:DSCResourceName)_Add_Config_With_Content" `
                         -OutputPath $TestDrive `
-                        -ConfigurationData $configDataForAddWithContent1
+                        -ConfigurationData $configDataForAddWithContent
                 } | Should -Not -Throw
             }
 
@@ -321,9 +299,9 @@ try
 
             It 'Should compile the MOF without throwing an exception' {
                 {
-                    & "$($script:DSCResourceName)_Add_Config" `
+                    & "$($script:DSCResourceName)_Add_Config_With_Content" `
                         -OutputPath $TestDrive `
-                        -ConfigurationData $configDataForAddWithContent2
+                        -ConfigurationData $configDataForAddWithContent
                 } | Should -Not -Throw
             }
 
@@ -358,7 +336,7 @@ try
         Context 'When certificate content has already been imported' {
             It 'Should compile the MOF without throwing an exception' {
                 {
-                    & "$($script:DSCResourceName)_Add_Config" `
+                    & "$($script:DSCResourceName)_Add_Config_With_Content" `
                         -OutputPath $TestDrive `
                         -ConfigurationData $configDataForAddWithContent
                 } | Should -Not -Throw

--- a/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
@@ -41,9 +41,13 @@ try
                 -Path $env:Temp `
                 -ChildPath "PfxImport-$($certificate.Thumbprint).pfx"
 
-            $pfxPathContentOutput = Join-Path `
+            $pfxPathContentOutput1 = Join-Path `
                 -Path $env:Temp `
-                -ChildPath "PfxContentImport-$($certificate.Thumbprint).pfx"
+                -ChildPath "PfxContentImport1-$($certificate.Thumbprint).pfx"
+
+            $pfxPathContentOutput2 = Join-Path `
+                -Path $env:Temp `
+                -ChildPath "PfxContentImport2-$($certificate.Thumbprint).pfx"
 
             $cerPath = Join-Path `
                 -Path $env:Temp `
@@ -90,7 +94,7 @@ try
                 )
             }
 
-            $configDataForAddWithContent = @{
+            $configDataForAddWithContent1 = @{
                 AllNodes = @(
                     @{
                         NodeName                    = 'localhost'
@@ -98,7 +102,24 @@ try
                         Location                    = 'LocalMachine'
                         Store                       = 'My'
                         Ensure                      = 'Present'
-                        Path                        = $pfxPathContentOutput
+                        Path                        = $pfxPathContentOutput1
+                        Content                     = $testBase64Content
+                        Credential                  = $testCredential
+                        FriendlyName                = $certificateFriendlyName
+                        PSDscAllowPlainTextPassword = $true
+                    }
+                )
+            }
+
+            $configDataForAddWithContent2 = @{
+                AllNodes = @(
+                    @{
+                        NodeName                    = 'localhost'
+                        Thumbprint                  = $certificate.Thumbprint
+                        Location                    = 'LocalMachine'
+                        Store                       = 'My'
+                        Ensure                      = 'Present'
+                        Path                        = $pfxPathContentOutput2
                         Content                     = $testBase64Content
                         Credential                  = $testCredential
                         FriendlyName                = $certificateFriendlyName
@@ -259,7 +280,7 @@ try
                 {
                     & "$($script:DSCResourceName)_Add_Config_With_Content" `
                         -OutputPath $TestDrive `
-                        -ConfigurationData $configDataForAddWithContent
+                        -ConfigurationData $configDataForAddWithContent1
                 } | Should -Not -Throw
             }
 
@@ -302,7 +323,7 @@ try
                 {
                     & "$($script:DSCResourceName)_Add_Config" `
                         -OutputPath $TestDrive `
-                        -ConfigurationData $configDataForAddWithContent
+                        -ConfigurationData $configDataForAddWithContent2
                 } | Should -Not -Throw
             }
 

--- a/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
@@ -97,7 +97,6 @@ try
                         Location                    = 'LocalMachine'
                         Store                       = 'My'
                         Ensure                      = 'Present'
-                        Path                        = $pfxPathContentOutput
                         Content                     = $testBase64Content
                         Credential                  = $testCredential
                         FriendlyName                = $certificateFriendlyName

--- a/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_PfxImport.Integration.Tests.ps1
@@ -40,6 +40,11 @@ try
             $pfxPath = Join-Path `
                 -Path $env:Temp `
                 -ChildPath "PfxImport-$($certificate.Thumbprint).pfx"
+
+            $pfxPathContentOutput = Join-Path `
+                -Path $env:Temp `
+                -ChildPath "PfxContentImport-$($certificate.Thumbprint).pfx"
+
             $cerPath = Join-Path `
                 -Path $env:Temp `
                 -ChildPath "CerImport-$($certificate.Thumbprint).cer"
@@ -54,6 +59,9 @@ try
                 -Cert $certificate `
                 -FilePath $pfxPath `
                 -Password $testCredential.Password
+
+            $contentByte = Get-Content -Path D:\ContentStore\Certificates\RpsRoot.cer -Encoding Byte
+            $testBase64Content = [System.Convert]::ToBase64String($contentByte)
 
             $null = Export-Certificate `
                 -Type CERT `
@@ -82,6 +90,23 @@ try
                 )
             }
 
+            $configDataForAddWithContent = @{
+                AllNodes = @(
+                    @{
+                        NodeName                    = 'localhost'
+                        Thumbprint                  = $certificate.Thumbprint
+                        Location                    = 'LocalMachine'
+                        Store                       = 'My'
+                        Ensure                      = 'Present'
+                        Path                        = $pfxPathContentOutput
+                        Content                     = $testBase64Content
+                        Credential                  = $testCredential
+                        FriendlyName                = $certificateFriendlyName
+                        PSDscAllowPlainTextPassword = $true
+                    }
+                )
+            }
+
             $configDataForRemove = @{
                 AllNodes = @(
                     @{
@@ -103,12 +128,16 @@ try
                 -Force `
                 -ErrorAction SilentlyContinue
             $null = Remove-Item `
+                -Path $pfxPathContentOutput `
+                -Force `
+                -ErrorAction SilentlyContinue
+            $null = Remove-Item `
                 -Path $certificate.PSPath `
                 -Force `
                 -ErrorAction SilentlyContinue
         }
 
-        Context 'When certificate has not been imported yet' {
+        Context 'When certificate file has not been imported yet' {
             It 'Should compile the MOF without throwing an exception' {
                 {
                     & "$($script:DSCResourceName)_Add_Config" `
@@ -145,7 +174,7 @@ try
             }
         }
 
-        Context 'When certificate has been imported but the private key is missing' {
+        Context 'When certificate file has been imported but the private key is missing' {
             $null = Remove-Item `
                 -Path $certificate.PSPath `
                 -Force
@@ -188,12 +217,129 @@ try
             }
         }
 
-        Context 'When certificate has already been imported' {
+        Context 'When certificate file has already been imported' {
             It 'Should compile the MOF without throwing an exception' {
                 {
                     & "$($script:DSCResourceName)_Add_Config" `
                         -OutputPath $TestDrive `
                         -ConfigurationData $configDataForAdd
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing an exception' {
+                {
+                    Start-DscConfiguration `
+                        -Path $TestDrive `
+                        -ComputerName localhost `
+                        -Wait `
+                        -Verbose `
+                        -Force `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                # Get the Certificate details
+                $certificateNew = Get-Item `
+                    -Path "Cert:\LocalMachine\My\$($certificate.Thumbprint)"
+                $certificateNew | Should -BeOfType System.Security.Cryptography.X509Certificates.X509Certificate2
+                $certificateNew.HasPrivateKey | Should -BeTrue
+                $certificateNew.Thumbprint | Should -BeExactly $certificate.Thumbprint
+                $certificateNew.Subject | Should -BeExactly $certificate.Subject
+                $certificateNew.FriendlyName | Should -BeExactly $certificateFriendlyName
+            }
+        }
+
+        Context 'When certificate content has not been imported yet' {
+            It 'Should compile the MOF without throwing an exception' {
+                {
+                    & "$($script:DSCResourceName)_Add_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configDataForAddWithContent
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing an exception' {
+                {
+                    Start-DscConfiguration `
+                        -Path $TestDrive `
+                        -ComputerName localhost `
+                        -Wait `
+                        -Verbose `
+                        -Force `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                # Get the Certificate details
+                $certificateNew = Get-Item `
+                    -Path "Cert:\LocalMachine\My\$($certificate.Thumbprint)"
+                $certificateNew | Should -BeOfType System.Security.Cryptography.X509Certificates.X509Certificate2
+                $certificateNew.HasPrivateKey | Should -Be $true
+                $certificateNew.Thumbprint | Should -BeExactly $certificate.Thumbprint
+                $certificateNew.Subject | Should -BeExactly $certificate.Subject
+                $certificateNew.FriendlyName | Should -BeExactly $certificateFriendlyName
+            }
+        }
+
+        Context 'When certificate content has been imported but the private key is missing' {
+            $null = Remove-Item `
+                -Path $certificate.PSPath `
+                -Force
+
+            Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\LocalMachine\My
+
+            It 'Should compile the MOF without throwing an exception' {
+                {
+                    & "$($script:DSCResourceName)_Add_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configDataForAddWithContent
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing an exception' {
+                {
+                    Start-DscConfiguration `
+                        -Path $TestDrive `
+                        -ComputerName localhost `
+                        -Wait `
+                        -Verbose `
+                        -Force `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                # Get the Certificate details
+                $certificateNew = Get-Item `
+                    -Path "Cert:\LocalMachine\My\$($certificate.Thumbprint)"
+                $certificateNew | Should -BeOfType System.Security.Cryptography.X509Certificates.X509Certificate2
+                $certificateNew.HasPrivateKey | Should -BeTrue
+                $certificateNew.Thumbprint | Should -BeExactly $certificate.Thumbprint
+                $certificateNew.Subject | Should -BeExactly $certificate.Subject
+                $certificateNew.FriendlyName | Should -BeExactly $certificateFriendlyName
+            }
+        }
+
+        Context 'When certificate content has already been imported' {
+            It 'Should compile the MOF without throwing an exception' {
+                {
+                    & "$($script:DSCResourceName)_Add_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configDataForAddWithContent
                 } | Should -Not -Throw
             }
 

--- a/tests/Integration/DSC_PfxImport.config.ps1
+++ b/tests/Integration/DSC_PfxImport.config.ps1
@@ -20,7 +20,6 @@ Configuration DSC_PfxImport_Add_Config_With_Content {
     node localhost {
         PfxImport Integration_Test {
             Thumbprint   = $Node.Thumbprint
-            Path         = $Node.Path
             Content      = $Node.Content
             Location     = $Node.Location
             Store        = $Node.Store

--- a/tests/Integration/DSC_PfxImport.config.ps1
+++ b/tests/Integration/DSC_PfxImport.config.ps1
@@ -14,6 +14,23 @@ Configuration DSC_PfxImport_Add_Config {
     }
 }
 
+Configuration DSC_PfxImport_Add_Config_With_Content {
+    Import-DscResource -ModuleName CertificateDsc
+
+    node localhost {
+        PfxImport Integration_Test {
+            Thumbprint   = $Node.Thumbprint
+            Path         = $Node.Path
+            Content      = $Node.Content
+            Location     = $Node.Location
+            Store        = $Node.Store
+            Ensure       = $Node.Ensure
+            Credential   = $Node.Credential
+            FriendlyName = $Node.FriendlyName
+        }
+    }
+}
+
 Configuration DSC_PfxImport_Remove_Config {
     Import-DscResource -ModuleName CertificateDsc
 

--- a/tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -168,7 +168,6 @@ InModuleScope $script:subModuleName {
             "
 
     $cerBytes = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithSan)
-    $base64Cer = [System.Convert]::ToBase64String($cerBytes)
     $cerBytesWithoutSan = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithoutSan)
     $cerBytesWithAltTemplateName = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithAltTemplateName)
     $cerBytesWithAltTemplateInformation = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithAltTemplateInformation)
@@ -1719,39 +1718,6 @@ Minor Version Number=5
                 Assert-MockCalled -CommandName Get-ChildItem -ParameterFilter {
                     $Path -eq 'Cert:\LocalMachine\TestStore\627b268587e95099e72aab831a81f887d7a20578'
                 } -Exactly -Times 1
-            }
-        }
-    }
-
-    Describe 'CertificateDsc.Common\Set-Base64Content' -Tag 'Set-Base64Content' {
-        Context 'When the value and path parameters are valid' {
-
-            It 'Should not throw exception' {
-                {
-                    Set-Base64Content -Path $validTmpPath -Value $base64Cer
-                } | Should -Not -Throw
-            }
-
-            It 'Should create expected file' {
-                Get-Content -Path $validTmpPath -Raw | Should -Be $cerFileWithSan
-            }
-        }
-
-        Context 'When the path is invalid' {
-
-            It 'Should throw exception' {
-                {
-                    Set-Base64Content -Path $inValidPath -Value $base64Cer
-                } | Should -Throw
-            }
-        }
-
-        Context 'When the value is invalid' {
-
-            It 'Should throw exception' {
-                {
-                    Set-Base64Content -Path $validPath -Value $cerFileWithSan
-                } | Should -Throw
             }
         }
     }

--- a/tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -40,9 +40,6 @@ InModuleScope $script:subModuleName {
     $invalidPath = 'TestDrive:'
     $validPath = "TestDrive:\$testFile"
 
-    $tmpCertificateName = $(New-Guid).Guid + '.cer'
-    $validTmpPath = Join-Path -Path $env:TMP -ChildPath $tmpCertificateName
-
     $cerFileWithSan = "
             -----BEGIN CERTIFICATE-----
             MIIGJDCCBAygAwIBAgITewAAAAqQ+bxgiZZPtgAAAAAACjANBgkqhkiG9w0BAQsF

--- a/tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -57,6 +57,9 @@ InModuleScope $script:subModuleName {
     $invalidPath = 'TestDrive:'
     $validPath = "TestDrive:\$testFile"
 
+    $tmpCertificateName = $(New-Guid).Guid + '.cer'
+    $validTmpPath = Join-Path -Path $env:TMP -ChildPath $tmpCertificateName
+
     $cerFileWithSan = "
             -----BEGIN CERTIFICATE-----
             MIIGJDCCBAygAwIBAgITewAAAAqQ+bxgiZZPtgAAAAAACjANBgkqhkiG9w0BAQsF
@@ -165,6 +168,7 @@ InModuleScope $script:subModuleName {
             "
 
     $cerBytes = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithSan)
+    $base64Cer = [System.Convert]::ToBase64String($cerBytes)
     $cerBytesWithoutSan = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithoutSan)
     $cerBytesWithAltTemplateName = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithAltTemplateName)
     $cerBytesWithAltTemplateInformation = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithAltTemplateInformation)
@@ -1715,6 +1719,39 @@ Minor Version Number=5
                 Assert-MockCalled -CommandName Get-ChildItem -ParameterFilter {
                     $Path -eq 'Cert:\LocalMachine\TestStore\627b268587e95099e72aab831a81f887d7a20578'
                 } -Exactly -Times 1
+            }
+        }
+    }
+
+    Describe 'CertificateDsc.Common\Set-Base64Content' -Tag 'Set-Base64Content' {
+        Context 'When the value and path parameters are valid' {
+
+            It 'Should not throw exception' {
+                {
+                    Set-Base64Content -Path $validTmpPath -Value $base64Cer
+                } | Should -Not -Throw
+            }
+
+            It 'Should create expected file' {
+                Get-Content -Path $validTmpPath -Raw | Should -Be $cerFileWithSan
+            }
+        }
+
+        Context 'When the path is invalid' {
+
+            It 'Should throw exception' {
+                {
+                    Set-Base64Content -Path $inValidPath -Value $base64Cer
+                } | Should -Throw
+            }
+        }
+
+        Context 'When the value is invalid' {
+
+            It 'Should throw exception' {
+                {
+                    Set-Base64Content -Path $validPath -Value $cerFileWithSan
+                } | Should -Throw
             }
         }
     }

--- a/tests/Unit/DSC_CertificateImport.Tests.ps1
+++ b/tests/Unit/DSC_CertificateImport.Tests.ps1
@@ -119,7 +119,6 @@ try
 
         $presentParamsWithFriendlyNameWithContent = @{
             Thumbprint   = $validThumbprint
-            Path         = $validPath
             Content      = $certificateContent
             Ensure       = 'Present'
             Location     = 'LocalMachine'
@@ -136,6 +135,24 @@ try
             Verbose      = $true
         }
 
+        $presentParamsWithBothContentAndPath = @{
+            Thumbprint   = $validThumbprint
+            Content      = $certificateContent
+            Path         = $validPath
+            Ensure       = 'Present'
+            Location     = 'LocalMachine'
+            Store        = 'My'
+            Verbose      = $true
+        }
+
+        $absentParamsWithBothContentAndPath = @{
+            Thumbprint   = $validThumbprint
+            Ensure       = 'Absent'
+            Location     = 'LocalMachine'
+            Store        = 'My'
+            Verbose      = $true
+        }
+
         $absentParams = @{
             Thumbprint = $validThumbprint
             Path       = $validPath
@@ -147,7 +164,6 @@ try
 
         $absentParamsWithContent = @{
             Thumbprint = $validThumbprint
-            Path       = $validPath
             Content    = $certificateContent
             Ensure     = 'Absent'
             Location   = 'LocalMachine'
@@ -224,6 +240,34 @@ try
         }
 
         Describe 'DSC_CertificateImport\Test-TargetResource' -Tag 'Test' {
+            Context 'When Content and Path parameters are null' {
+                It 'Should throw exception when Ensure is Present' {
+                    {
+                        Test-TargetResource @presentParamsWithoutContentAndPath
+                    } | Should -Throw
+                }
+
+                It 'Should not throw exception when Ensure is Absent' {
+                    {
+                        Test-TargetResource @absentParamsWithoutContentAndPath
+                    } | Should -Not -Throw
+                }
+            }
+
+            Context 'When both Content and Path parameters are set' {
+                It 'Should throw exception when Ensure is Present' {
+                    {
+                        Test-TargetResource @presentParamsWithBothContentAndPath
+                    } | Should -Throw ($script:localizedData.ContentAndPathParametersAreSet)
+                }
+
+                It 'Should not throw exception when Ensure is Absent' {
+                    {
+                        Test-TargetResource @absentParamsWithBothContentAndPath
+                    } | Should -Not -Throw
+                }
+            }
+
             Context 'When certificate is not in store but should be' {
                 Mock -CommandName Get-CertificateFromCertificateStore
 
@@ -286,15 +330,29 @@ try
             }
 
             Context 'When Content and Path parameters are null' {
-                It 'Should throw exception wnen Ensure is Present' {
+                It 'Should throw exception when Ensure is Present' {
                     {
                         Set-TargetResource @presentParamsWithoutContentAndPath
                     } | Should -Throw
                 }
 
-                It 'Should not throw exception wnen Ensure is Absent' {
+                It 'Should not throw exception when Ensure is Absent' {
                     {
                         Set-TargetResource @absentParamsWithoutContentAndPath
+                    } | Should -Not -Throw
+                }
+            }
+
+            Context 'When both Content and Path parameters are set' {
+                It 'Should throw exception when Ensure is Present' {
+                    {
+                        Set-TargetResource @presentParamsWithBothContentAndPath
+                    } | Should -Throw ($script:localizedData.ContentAndPathParametersAreSet)
+                }
+
+                It 'Should not throw exception when Ensure is Absent' {
+                    {
+                        Set-TargetResource @absentParamsWithBothContentAndPath
                     } | Should -Not -Throw
                 }
             }

--- a/tests/Unit/DSC_CertificateImport.Tests.ps1
+++ b/tests/Unit/DSC_CertificateImport.Tests.ps1
@@ -70,25 +70,20 @@ try
             $Path -eq $validPath
         }
 
-        $setBase64Content_parameterfilter = {
-            $Path -eq $validPath -and `
-                $Value -eq $certificateContent
-        }
-
-        $removeItem_parameterfilter = {
-            $Path -eq $validPath -and `
-                $force -eq $true
-        }
-
         $getCertificateFromCertificateStore_parameterfilter = {
             $Thumbprint -eq $validThumbprint -and `
                 $Location -eq 'LocalMachine' -and `
                 $Store -eq 'My'
         }
 
-        $importCertificateEx_parameterfilter = {
+        $importCertificateExWithFile_parameterfilter = {
             $CertStoreLocation -eq $validCertPath -and `
                 $FilePath -eq $validPath
+        }
+
+        $importCertificateExWithContent_parameterfilter = {
+            $CertStoreLocation -eq $validCertPath -and `
+                $Base64Content -eq $certificateContent
         }
 
         $setCertificateFriendlyNameInCertificateStore_parameterfilter = {
@@ -278,12 +273,10 @@ try
 
         Describe 'DSC_CertificateImport\Set-TargetResource' -Tag 'Set' {
             BeforeAll {
-                Mock -CommandName Set-Base64Content
                 Mock -CommandName Test-Path -MockWith { $true }
                 Mock -CommandName Import-CertificateEx
                 Mock -CommandName Remove-CertificateFromCertificateStore
                 Mock -CommandName Set-CertificateFriendlyNameInCertificateStore
-                Mock -CommandName Remove-Item
             }
 
             Context 'When certificate file exists and certificate should be in the store but is not' {
@@ -293,10 +286,6 @@ try
                     {
                         Set-TargetResource @presentParams
                     } | Should -Not -Throw
-                }
-
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should call Test-Path with expected parameters' {
@@ -309,12 +298,8 @@ try
                 It 'Should call Import-Certificate with expected parameters' {
                     Assert-MockCalled `
                         -CommandName Import-CertificateEx `
-                        -ParameterFilter $importCertificateEx_parameterfilter `
+                        -ParameterFilter $importCertificateExWithFile_parameterfilter `
                         -Exactly -Times 1
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -335,31 +320,14 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should call Set-Base64Content with expected parameters' {
-                    Assert-MockCalled `
-                        -CommandName Set-Base64Content `
-                        -ParameterFilter $setBase64Content_parameterfilter `
-                        -Exactly -Times 1
-                }
-
                 It 'Should call Test-Path with expected parameters' {
-                    Assert-MockCalled `
-                        -CommandName Test-Path `
-                        -ParameterFilter $testPath_parameterfilter `
-                        -Exactly -Times 1
+                    Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should call Import-Certificate with expected parameters' {
                     Assert-MockCalled `
                         -CommandName Import-CertificateEx `
-                        -ParameterFilter $importCertificateEx_parameterfilter `
-                        -Exactly -Times 1
-                }
-
-                It 'Should call Remove-Item with expected parameters' {
-                    Assert-MockCalled `
-                        -CommandName Remove-Item `
-                        -ParameterFilter $removeItem_parameterfilter `
+                        -ParameterFilter $importCertificateExWithContent_parameterfilter `
                         -Exactly -Times 1
                 }
 
@@ -382,20 +350,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-Certificate' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -417,20 +377,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-Certificate' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -452,20 +404,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-Certificate' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should call Set-CertificateFriendlyNameInCertificateStore with expected parameters' {
@@ -490,20 +434,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-Certificate' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should call Set-CertificateFriendlyNameInCertificateStore with expected parameters' {
@@ -528,20 +464,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-Certificate' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -563,20 +491,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-Certificate' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -598,20 +518,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-CertificateEx' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -636,20 +548,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-CertificateEx' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -673,20 +577,12 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
                 It 'Should not call Import-CertificateEx' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -701,17 +597,13 @@ try
                 }
             }
 
-            Context 'When certificate content exists and certificate should not be in the store and is not' {
+            Context 'When certificate content is used and certificate should not be in the store and is not' {
                 Mock -CommandName Get-CertificateFromCertificateStore
 
                 It 'Should not throw exception' {
                     {
-                        Set-TargetResource @absentParams
+                        Set-TargetResource @absentParamsWithContent
                     } | Should -Not -Throw
-                }
-
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -720,10 +612,6 @@ try
 
                 It 'Should not call Import-CertificateEx' {
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
@@ -747,10 +635,6 @@ try
                     } | Should -Throw ($script:localizedData.CertificatePfxFileNotFoundError -f $validPath)
                 }
 
-                It 'Should not call Set-Base64Content' {
-                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
-                }
-
                 It 'Should call Test-Path with the parameters supplied' {
                     Assert-MockCalled `
                         -CommandName Test-Path `
@@ -762,10 +646,6 @@ try
                     Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
                 }
 
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
-                }
-
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {
                     Assert-MockCalled -CommandName Set-CertificateFriendlyNameInCertificateStore -Exactly -Times 0
                 }
@@ -775,8 +655,8 @@ try
                 }
             }
 
-            Context 'When certificate content can not be written due to bad path and certificate should be in the store' {
-                Mock -CommandName Set-Base64Content -MockWith { throw }
+            Context 'When certificate content is invalid and certificate should be in the store' {
+                Mock -CommandName Import-CertificateEx -MockWith { throw }
 
                 It 'Should throw exception' {
                     {
@@ -784,23 +664,15 @@ try
                     } | Should -Throw
                 }
 
-                It 'Should call Set-Base64Content with the parameters supplied' {
-                    Assert-MockCalled `
-                        -CommandName Set-Base64Content `
-                        -ParameterFilter $setBase64Content_parameterfilter `
-                        -Exactly -Times 1
-                }
-
                 It 'Should not call Test-Path' {
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 0
                 }
 
-                It 'Should not call Import-CertificateEx' {
-                    Assert-MockCalled -CommandName Import-CertificateEx -Exactly -Times 0
-                }
-
-                It 'Should not call Remove-Item' {
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 0
+                It 'Should call Import-Certificate with expected parameters' {
+                    Assert-MockCalled `
+                        -CommandName Import-CertificateEx `
+                        -ParameterFilter $importCertificateExWithContent_parameterfilter `
+                        -Exactly -Times 1
                 }
 
                 It 'Should not call Set-CertificateFriendlyNameInCertificateStore' {

--- a/tests/Unit/DSC_CertificateImport.Tests.ps1
+++ b/tests/Unit/DSC_CertificateImport.Tests.ps1
@@ -110,7 +110,6 @@ try
 
         $presentParamsWithContent = @{
             Thumbprint   = $validThumbprint
-            Path         = $validPath
             Content      = $certificateContent
             Ensure       = 'Present'
             Location     = 'LocalMachine'
@@ -209,7 +208,7 @@ try
 
                 It 'Should not throw exception' {
                     {
-                        $script:result = Get-TargetResource @presentParams
+                        $script:result = Get-TargetResource @presentParamsWithContent
                     } | Should -Not -Throw
                 }
 
@@ -219,7 +218,8 @@ try
 
                 It 'Should contain the input values' {
                     $script:result.Thumbprint | Should -BeExactly $validThumbprint
-                    $script:result.Path | Should -BeExactly $validPath
+                    $script:result.Path | Should -BeExactly ''
+                    $script:result.Content | Should -BeExactly $presentParamsWithContent.Content
                     $script:result.Ensure | Should -BeExactly 'Absent'
                     $script:result.FriendlyName | Should -BeNullOrEmpty
                 }

--- a/tests/Unit/DSC_CertificateImport.Tests.ps1
+++ b/tests/Unit/DSC_CertificateImport.Tests.ps1
@@ -47,7 +47,7 @@ try
         $testFile = 'test.cer'
         $certificateFriendlyName = 'Test Certificate Friendly Name'
 
-        $certificateContent = 'Test certificate content'
+        $certificateContent = [System.Convert]::ToBase64String(@(00, 00, 00))
 
         $validPath = "TestDrive:\$testFile"
         $validCertPath = "Cert:\LocalMachine\My"
@@ -70,7 +70,7 @@ try
             $Path -eq $validPath
         }
 
-        $setContent_parameterfilter = {
+        $setBase64Content_parameterfilter = {
             $Path -eq $validPath -and `
                 $Value -eq $certificateContent
         }
@@ -278,7 +278,7 @@ try
 
         Describe 'DSC_CertificateImport\Set-TargetResource' -Tag 'Set' {
             BeforeAll {
-                Mock -CommandName Set-Content
+                Mock -CommandName Set-Base64Content
                 Mock -CommandName Test-Path -MockWith { $true }
                 Mock -CommandName Import-CertificateEx
                 Mock -CommandName Remove-CertificateFromCertificateStore
@@ -295,8 +295,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should call Test-Path with expected parameters' {
@@ -335,10 +335,10 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should call Set-Content with expected parameters' {
+                It 'Should call Set-Base64Content with expected parameters' {
                     Assert-MockCalled `
-                        -CommandName Set-Content `
-                        -ParameterFilter $setContent_parameterfilter `
+                        -CommandName Set-Base64Content `
+                        -ParameterFilter $setBase64Content_parameterfilter `
                         -Exactly -Times 1
                 }
 
@@ -382,8 +382,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -417,8 +417,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -452,8 +452,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -490,8 +490,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -528,8 +528,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -563,8 +563,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -598,8 +598,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -636,8 +636,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -673,8 +673,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -710,8 +710,8 @@ try
                     } | Should -Not -Throw
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should not call Test-Path' {
@@ -747,8 +747,8 @@ try
                     } | Should -Throw ($script:localizedData.CertificatePfxFileNotFoundError -f $validPath)
                 }
 
-                It 'Should not call Set-Content' {
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 0
+                It 'Should not call Set-Base64Content' {
+                    Assert-MockCalled -CommandName Set-Base64Content -Exactly -Times 0
                 }
 
                 It 'Should call Test-Path with the parameters supplied' {
@@ -776,7 +776,7 @@ try
             }
 
             Context 'When certificate content can not be written due to bad path and certificate should be in the store' {
-                Mock -CommandName Set-Content -MockWith { throw }
+                Mock -CommandName Set-Base64Content -MockWith { throw }
 
                 It 'Should throw exception' {
                     {
@@ -784,10 +784,10 @@ try
                     } | Should -Throw
                 }
 
-                It 'Should call Set-Content with the parameters supplied' {
+                It 'Should call Set-Base64Content with the parameters supplied' {
                     Assert-MockCalled `
-                        -CommandName Set-Content `
-                        -ParameterFilter $setContent_parameterfilter `
+                        -CommandName Set-Base64Content `
+                        -ParameterFilter $setBase64Content_parameterfilter `
                         -Exactly -Times 1
                 }
 

--- a/tests/Unit/DSC_CertificateImport.Tests.ps1
+++ b/tests/Unit/DSC_CertificateImport.Tests.ps1
@@ -139,6 +139,14 @@ try
             FriendlyName = $certificateFriendlyName
         }
 
+        $presentParamsWithoutContentAndPath = @{
+            Thumbprint   = $validThumbprint
+            Ensure       = 'Present'
+            Location     = 'LocalMachine'
+            Store        = 'My'
+            Verbose      = $true
+        }
+
         $absentParams = @{
             Thumbprint = $validThumbprint
             Path       = $validPath
@@ -152,6 +160,14 @@ try
             Thumbprint = $validThumbprint
             Path       = $validPath
             Content    = $certificateContent
+            Ensure     = 'Absent'
+            Location   = 'LocalMachine'
+            Store      = 'My'
+            Verbose    = $true
+        }
+
+        $absentParamsWithoutContentAndPath = @{
+            Thumbprint = $validThumbprint
             Ensure     = 'Absent'
             Location   = 'LocalMachine'
             Store      = 'My'
@@ -277,6 +293,20 @@ try
                 Mock -CommandName Import-CertificateEx
                 Mock -CommandName Remove-CertificateFromCertificateStore
                 Mock -CommandName Set-CertificateFriendlyNameInCertificateStore
+            }
+
+            Context 'When Content and Path parameters are null' {
+                It 'Should throw exception wnen Ensure is Present' {
+                    {
+                        Set-TargetResource @presentParamsWithoutContentAndPath
+                    } | Should -Throw
+                }
+
+                It 'Should not throw exception wnen Ensure is Absent' {
+                    {
+                        Set-TargetResource @absentParamsWithoutContentAndPath
+                    } | Should -Not -Throw
+                }
             }
 
             Context 'When certificate file exists and certificate should be in the store but is not' {

--- a/tests/Unit/DSC_PfxImport.Tests.ps1
+++ b/tests/Unit/DSC_PfxImport.Tests.ps1
@@ -172,6 +172,17 @@ try
             FriendlyName = $certificateFriendlyName
         }
 
+        $presentParamsWithoutContentAndPath = @{
+            Thumbprint   = $validThumbprint
+            Ensure       = 'Present'
+            Location     = 'LocalMachine'
+            Store        = 'My'
+            Exportable   = $True
+            Credential   = $testCredential
+            Verbose      = $True
+            FriendlyName = $certificateFriendlyName
+        }
+
         $absentParams = @{
             Thumbprint = $validThumbprint
             Ensure     = 'Absent'
@@ -183,6 +194,14 @@ try
         $absentParamsWithContent = @{
             Thumbprint = $validThumbprint
             Content    = $certificateContent
+            Ensure     = 'Absent'
+            Location   = 'LocalMachine'
+            Store      = 'My'
+            Verbose    = $True
+        }
+
+        $absentParamsWithoutContentAndPath = @{
+            Thumbprint = $validThumbprint
             Ensure     = 'Absent'
             Location   = 'LocalMachine'
             Store      = 'My'
@@ -338,6 +357,20 @@ try
                 Mock -CommandName Import-PfxCertificateEx
                 Mock -CommandName Remove-CertificateFromCertificateStore
                 Mock -CommandName Set-CertificateFriendlyNameInCertificateStore
+            }
+
+            Context 'When Content and Path parameters are null' {
+                It 'Should throw exception wnen Ensure is Present' {
+                    {
+                        Set-TargetResource @presentParamsWithoutContentAndPath
+                    } | Should -Throw ($script:localizedData.ContentAndPathParametersAreNull)
+                }
+
+                It 'Should not throw exception wnen Ensure is Absent' {
+                    {
+                        Set-TargetResource @absentParamsWithoutContentAndPath
+                    } | Should -Not -Throw
+                }
             }
 
             Context 'When PFX file exists and certificate should be in the store but is not' {

--- a/tests/Unit/DSC_PfxImport.Tests.ps1
+++ b/tests/Unit/DSC_PfxImport.Tests.ps1
@@ -149,7 +149,6 @@ try
 
         $presentParamsWithFriendlyNameWithContent = @{
             Thumbprint   = $validThumbprint
-            Path         = $validPath
             Content      = $certificateContent
             Ensure       = 'Present'
             Location     = 'LocalMachine'
@@ -163,6 +162,32 @@ try
         $presentParamsWithoutContentAndPath = @{
             Thumbprint   = $validThumbprint
             Ensure       = 'Present'
+            Location     = 'LocalMachine'
+            Store        = 'My'
+            Exportable   = $True
+            Credential   = $testCredential
+            Verbose      = $True
+            FriendlyName = $certificateFriendlyName
+        }
+
+        $presentParamsWithBothContentAndPath = @{
+            Thumbprint   = $validThumbprint
+            Content      = $certificateContent
+            Path         = $validPath
+            Ensure       = 'Present'
+            Location     = 'LocalMachine'
+            Store        = 'My'
+            Exportable   = $True
+            Credential   = $testCredential
+            Verbose      = $True
+            FriendlyName = $certificateFriendlyName
+        }
+
+        $absentParamsWithBothContentAndPath = @{
+            Thumbprint   = $validThumbprint
+            Content      = $certificateContent
+            Path         = $validPath
+            Ensure       = 'Absent'
             Location     = 'LocalMachine'
             Store        = 'My'
             Exportable   = $True
@@ -286,6 +311,34 @@ try
         }
 
         Describe 'DSC_PfxImport\Test-TargetResource' -Tag 'Test' {
+            Context 'When Content and Path parameters are null' {
+                It 'Should throw exception when Ensure is Present' {
+                    {
+                        Test-TargetResource @presentParamsWithoutContentAndPath
+                    } | Should -Throw
+                }
+
+                It 'Should not throw exception when Ensure is Absent' {
+                    {
+                        Test-TargetResource @absentParamsWithoutContentAndPath
+                    } | Should -Not -Throw
+                }
+            }
+
+            Context 'When both Content and Path parameters are set' {
+                It 'Should throw exception when Ensure is Present' {
+                    {
+                        Test-TargetResource @presentParamsWithBothContentAndPath
+                    } | Should -Throw ($script:localizedData.ContentAndPathParametersAreSet)
+                }
+
+                It 'Should not throw exception when Ensure is Absent' {
+                    {
+                        Test-TargetResource @absentParamsWithBothContentAndPath
+                    } | Should -Not -Throw
+                }
+            }
+
             Context 'When certificate is not in store but should be' {
                 Mock -CommandName Get-CertificateFromCertificateStore
 
@@ -349,15 +402,29 @@ try
             }
 
             Context 'When Content and Path parameters are null' {
-                It 'Should throw exception wnen Ensure is Present' {
+                It 'Should throw exception when Ensure is Present' {
                     {
                         Set-TargetResource @presentParamsWithoutContentAndPath
                     } | Should -Throw ($script:localizedData.ContentAndPathParametersAreNull)
                 }
 
-                It 'Should not throw exception wnen Ensure is Absent' {
+                It 'Should not throw exception when Ensure is Absent' {
                     {
                         Set-TargetResource @absentParamsWithoutContentAndPath
+                    } | Should -Not -Throw
+                }
+            }
+
+            Context 'When both Content and Path parameters are set' {
+                It 'Should throw exception when Ensure is Present' {
+                    {
+                        Set-TargetResource @presentParamsWithBothContentAndPath
+                    } | Should -Throw ($script:localizedData.ContentAndPathParametersAreSet)
+                }
+
+                It 'Should not throw exception when Ensure is Absent' {
+                    {
+                        Set-TargetResource @absentParamsWithBothContentAndPath
                     } | Should -Not -Throw
                 }
             }

--- a/tests/Unit/DSC_PfxImport.Tests.ps1
+++ b/tests/Unit/DSC_PfxImport.Tests.ps1
@@ -137,7 +137,6 @@ try
 
         $presentParamsWithContent = @{
             Thumbprint = $validThumbprint
-            Path       = $validPath
             Content    = $certificateContent
             Ensure     = 'Present'
             Location   = 'LocalMachine'
@@ -272,7 +271,7 @@ try
 
                 It 'Should not throw exception' {
                     {
-                        $script:result = Get-TargetResource @presentParams
+                        $script:result = Get-TargetResource @presentParamsWithContent
                     } | Should -Not -Throw
                 }
 
@@ -282,7 +281,8 @@ try
 
                 It 'Should contain the input values' {
                     $script:result.Thumbprint | Should -BeExactly $validThumbprint
-                    $script:result.Path | Should -BeExactly $validPath
+                    $script:result.Path | Should -BeExactly ''
+                    $script:result.Content | Should -Be $presentParamsWithContent.Content
                     $script:result.Ensure | Should -BeExactly 'Absent'
                     $script:result.FriendlyName | Should -BeNullOrEmpty
                 }

--- a/tests/Unit/DSC_PfxImport.Tests.ps1
+++ b/tests/Unit/DSC_PfxImport.Tests.ps1
@@ -55,11 +55,7 @@ try
             -TypeName System.Management.Automation.PSCredential `
             -ArgumentList $testUsername, (ConvertTo-SecureString $testPassword -AsPlainText -Force)
 
-            $enc = [system.Text.Encoding]::UTF8
-
-
-
-        $testContent = 'Test certificate content'
+        $certificateContent = [System.Convert]::ToBase64String(@(00, 00, 00))
 
         $validPath = "TestDrive:\$testFile"
         $validCertPath = "Cert:\LocalMachine\My"
@@ -97,7 +93,7 @@ try
 
         $setBase64Content_parameterfilter = {
             $Path -eq $validPath -and `
-                $Value -eq $testContent
+                $Value -eq $certificateContent
         }
 
         $removeItem_parameterfilter = {
@@ -145,7 +141,7 @@ try
         $presentParamsWithContent = @{
             Thumbprint = $validThumbprint
             Path       = $validPath
-            Content    = $testContent
+            Content    = $certificateContent
             Ensure     = 'Present'
             Location   = 'LocalMachine'
             Store      = 'My'
@@ -169,7 +165,7 @@ try
         $presentParamsWithFriendlyNameWithContent = @{
             Thumbprint   = $validThumbprint
             Path         = $validPath
-            Content      = $testContent
+            Content      = $certificateContent
             Ensure       = 'Present'
             Location     = 'LocalMachine'
             Store        = 'My'
@@ -189,7 +185,7 @@ try
 
         $absentParamsWithContent = @{
             Thumbprint = $validThumbprint
-            Content    = $testContent
+            Content    = $certificateContent
             Ensure     = 'Absent'
             Location   = 'LocalMachine'
             Store      = 'My'


### PR DESCRIPTION
#### Pull Request (PR) description
Updated the resources ImportPFX and ImportCertificate with the following:
* Added Base64Content parameter to specify the content of a PFX file that can be included in the configuration MOF.
* Added Base64Content parameter to specify the content of a certificate file that can be included in the configuration MOF.
* Updated unit and integration tests

#### This Pull Request (PR) fixes the following issues
- Issue #241 

#### Task list
- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/certificatedsc/242)
<!-- Reviewable:end -->
