### PR TITLE
DSC_ImportPfx: Update private key import location for LocalMachine using Import-PfxCertificateEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix bug where `Import-PfxCertificateEx` would not install private keys in the ALLUSERSPROFILE path when importing to LocalMachine store. [Issue #248](https://github.com/dsccommunity/CertificateDsc/issues/248).
+
 ## [5.0.0] - 2020-10-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2020-10-16
+
 ### Changed
 
 - Corrected incorrectly located entries in `CHANGELOG.MD`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - PfxImport:
-  - Added Base64Content parameter to specify the content of a PFX file that can be included in the configuration MOF - Fixes [Issue #241](https://github.com/dsccommunity/CertificateDsc/issues/241).
+  - Added Base64Content parameter to specify the content of a PFX file that can be included in the
+  configuration MOF - Fixes [Issue #241](https://github.com/dsccommunity/CertificateDsc/issues/241).
 - CertificateImport:
-  - Added Base64Content parameter to specify the content of a certificate file that can be included in the configuration MOF - Fixes [Issue #241](https://github.com/dsccommunity/CertificateDsc/issues/241).
+  - Added Base64Content parameter to specify the content of a certificate file that can be included
+  in the configuration MOF - Fixes [Issue #241](https://github.com/dsccommunity/CertificateDsc/issues/241).
 
 ### Changed
 
-- Fix bug where `Import-PfxCertificateEx` would not install private keys in the ALLUSERSPROFILE path when importing to LocalMachine store. [Issue #248](https://github.com/dsccommunity/CertificateDsc/issues/248).
+- Fix bug where `Import-PfxCertificateEx` would not install private keys in the ALLUSERSPROFILE path
+when importing to LocalMachine store. [Issue #248](https://github.com/dsccommunity/CertificateDsc/issues/248).
 - Renamed `master` branch to `main` - Fixes [Issue #237](https://github.com/dsccommunity/CertificateDsc/issues/237).
 - Updated `GitVersion.yml` to latest pattern - Fixes [Issue #245](https://github.com/dsccommunity/CertificateDsc/issues/245).
 - Changed `Test-Thumbprint` to cache supported hash algorithms to increase

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -973,6 +973,10 @@ function Import-PfxCertificateEx
     {
         $flags = $flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::MachineKeySet
     }
+    else
+    {
+        $flags = $flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::UserKeySet
+    }
 
     if ($Exportable)
     {

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -969,6 +969,11 @@ function Import-PfxCertificateEx
 
     $flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
 
+    if ($location -eq 'LocalMachine')
+    {
+        $flags = $flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::MachineKeySet
+    }
+
     if ($Exportable)
     {
         $flags = $flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable

--- a/tests/Integration/CertificateDsc.Common.Tests.ps1
+++ b/tests/Integration/CertificateDsc.Common.Tests.ps1
@@ -182,36 +182,36 @@ InModuleScope $script:subModuleName {
 
             # Remove the imported certificate
             Remove-Item -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+        }
 
-            Context 'Import a valid PKCS12 PFX Certificate file into "LocalMachine\My" store with non-exportable key' {
-                It 'Should not throw an exception' {
-                    { Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\LocalMachine\My' -Password $testPasswordSecure } | Should -Not -Throw
-                }
-
-                It 'Should have imported the certificate with the correct values' {
-                    $importedCert = Get-ChildItem -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint)
-                    $importedCert.PrivateKey.CspKeyContainerInfo.MachineKeyStore | Should -Be $true
-                    $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
-                    $importedCert.HasPrivateKey | Should -Be $true
-                }
-
-                It 'Should not be exportable and should throw the expected exception message' {
-                    $importedCert = Get-ChildItem -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint)
-                    { $null = Export-PfxCertificate `
-                            -Cert $importedCert `
-                            -FilePath $certificateExportPath `
-                            -Password $testCredential.Password
-                    } | Should -Throw 'Cannot export non-exportable private key.'
-
-                    $null = Remove-Item `
-                        -Path $certificateExportPath `
-                        -Force `
-                        -ErrorAction SilentlyContinue
-                }
-
-                # Remove the imported certificate
-                Remove-Item -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+        Context 'Import a valid PKCS12 PFX Certificate file into "LocalMachine\My" store with non-exportable key' {
+            It 'Should not throw an exception' {
+                { Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\LocalMachine\My' -Password $testPasswordSecure } | Should -Not -Throw
             }
+
+            It 'Should have imported the certificate with the correct values' {
+                $importedCert = Get-ChildItem -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint)
+                $importedCert.PrivateKey.CspKeyContainerInfo.MachineKeyStore | Should -Be $true
+                $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
+                $importedCert.HasPrivateKey | Should -Be $true
+            }
+
+            It 'Should not be exportable and should throw the expected exception message' {
+                $importedCert = Get-ChildItem -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint)
+                { $null = Export-PfxCertificate `
+                        -Cert $importedCert `
+                        -FilePath $certificateExportPath `
+                        -Password $testCredential.Password
+                } | Should -Throw 'Cannot export non-exportable private key.'
+                $null = Remove-Item `
+                    -Path $certificateExportPath `
+                    -Force `
+                    -ErrorAction SilentlyContinue
+            }
+
+            # Remove the imported certificate
+            Remove-Item -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+        }
 
         Context 'Import a valid PKCS12 PFX Certificate file into "CurrentUser\My" store with exportable key' {
             It 'Should not throw an exception' {

--- a/tests/Integration/CertificateDsc.Common.Tests.ps1
+++ b/tests/Integration/CertificateDsc.Common.Tests.ps1
@@ -62,7 +62,7 @@ InModuleScope $script:subModuleName {
             It 'Should have imported the certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
                 $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
-                $importedCert.HasPrivateKey | Should -Be $false
+                $importedCert.HasPrivateKey | Should -BeFalse
             }
         }
     }
@@ -112,13 +112,13 @@ InModuleScope $script:subModuleName {
             It 'Should have imported the containing certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $containingCertificate.Thumbprint)
                 $importedCert.Thumbprint | Should -Be $containingCertificate.Thumbprint
-                $importedCert.HasPrivateKey | Should -Be $false
+                $importedCert.HasPrivateKey | Should -BeFalse
             }
 
             It 'Should have imported the included certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $includedCertificate.Thumbprint)
                 $importedCert.Thumbprint | Should -Be $includedCertificate.Thumbprint
-                $importedCert.HasPrivateKey | Should -Be $false
+                $importedCert.HasPrivateKey | Should -BeFalse
             }
         }
     }
@@ -164,9 +164,9 @@ InModuleScope $script:subModuleName {
             It 'Should have imported the certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
                 $rsaKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($importedCert)
-                $rsaKey.Key.IsMachineKey | Should -Be $false
+                $rsaKey.Key.IsMachineKey | Should -BeFalse
                 $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
-                $importedCert.HasPrivateKey | Should -Be $true
+                $importedCert.HasPrivateKey | Should -BeTrue
             }
 
             It 'Should not be exportable and should throw the expected exception message' {
@@ -197,9 +197,9 @@ InModuleScope $script:subModuleName {
             It 'Should have imported the certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint)
                 $rsaKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($importedCert)
-                $rsaKey.Key.IsMachineKey | Should -Be $true
+                $rsaKey.Key.IsMachineKey | Should -BeTrue
                 $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
-                $importedCert.HasPrivateKey | Should -Be $true
+                $importedCert.HasPrivateKey | Should -BeTrue
             }
 
             It 'Should not be exportable and should throw the expected exception message' {
@@ -209,6 +209,7 @@ InModuleScope $script:subModuleName {
                         -FilePath $certificateExportPath `
                         -Password $testCredential.Password
                 } | Should -Throw 'Cannot export non-exportable private key.'
+
                 $null = Remove-Item `
                     -Path $certificateExportPath `
                     -Force `
@@ -227,7 +228,7 @@ InModuleScope $script:subModuleName {
             It 'Should have imported the certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
                 $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
-                $importedCert.HasPrivateKey | Should -Be $true
+                $importedCert.HasPrivateKey | Should -BeTrue
             }
 
             It 'Should be exportable' {

--- a/tests/Integration/CertificateDsc.Common.Tests.ps1
+++ b/tests/Integration/CertificateDsc.Common.Tests.ps1
@@ -161,6 +161,7 @@ InModuleScope $script:subModuleName {
 
             It 'Should have imported the certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
+                $importedCert.PrivateKey.CspKeyContainerInfo.MachineKeyStore | Should -Be $false
                 $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
                 $importedCert.HasPrivateKey | Should -Be $true
             }
@@ -181,7 +182,36 @@ InModuleScope $script:subModuleName {
 
             # Remove the imported certificate
             Remove-Item -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint) -Force -ErrorAction SilentlyContinue
-        }
+
+            Context 'Import a valid PKCS12 PFX Certificate file into "LocalMachine\My" store with non-exportable key' {
+                It 'Should not throw an exception' {
+                    { Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\LocalMachine\My' -Password $testPasswordSecure } | Should -Not -Throw
+                }
+
+                It 'Should have imported the certificate with the correct values' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint)
+                    $importedCert.PrivateKey.CspKeyContainerInfo.MachineKeyStore | Should -Be $true
+                    $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
+                    $importedCert.HasPrivateKey | Should -Be $true
+                }
+
+                It 'Should not be exportable and should throw the expected exception message' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint)
+                    { $null = Export-PfxCertificate `
+                            -Cert $importedCert `
+                            -FilePath $certificateExportPath `
+                            -Password $testCredential.Password
+                    } | Should -Throw 'Cannot export non-exportable private key.'
+
+                    $null = Remove-Item `
+                        -Path $certificateExportPath `
+                        -Force `
+                        -ErrorAction SilentlyContinue
+                }
+
+                # Remove the imported certificate
+                Remove-Item -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+            }
 
         Context 'Import a valid PKCS12 PFX Certificate file into "CurrentUser\My" store with exportable key' {
             It 'Should not throw an exception' {

--- a/tests/Integration/CertificateDsc.Common.Tests.ps1
+++ b/tests/Integration/CertificateDsc.Common.Tests.ps1
@@ -156,12 +156,15 @@ InModuleScope $script:subModuleName {
     Describe 'CertificateDsc.Common\Import-PfxCertificateEx' {
         Context 'Import a valid PKCS12 PFX Certificate file into "CurrentUser\My" store with non-exportable key' {
             It 'Should not throw an exception' {
-                { Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\CurrentUser\My' -Password $testPasswordSecure } | Should -Not -Throw
+                {
+                    Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\CurrentUser\My' -Password $testPasswordSecure
+                } | Should -Not -Throw
             }
 
             It 'Should have imported the certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
-                $importedCert.PrivateKey.CspKeyContainerInfo.MachineKeyStore | Should -Be $false
+                $rsaKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($importedCert)
+                $rsaKey.Key.IsMachineKey | Should -Be $false
                 $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
                 $importedCert.HasPrivateKey | Should -Be $true
             }
@@ -186,12 +189,15 @@ InModuleScope $script:subModuleName {
 
         Context 'Import a valid PKCS12 PFX Certificate file into "LocalMachine\My" store with non-exportable key' {
             It 'Should not throw an exception' {
-                { Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\LocalMachine\My' -Password $testPasswordSecure } | Should -Not -Throw
+                {
+                    Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\LocalMachine\My' -Password $testPasswordSecure
+                } | Should -Not -Throw
             }
 
             It 'Should have imported the certificate with the correct values' {
                 $importedCert = Get-ChildItem -Path ('Cert:\LocalMachine\My\{0}' -f $certificate.Thumbprint)
-                $importedCert.PrivateKey.CspKeyContainerInfo.MachineKeyStore | Should -Be $true
+                $rsaKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($importedCert)
+                $rsaKey.Key.IsMachineKey | Should -Be $true
                 $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
                 $importedCert.HasPrivateKey | Should -Be $true
             }

--- a/tests/Integration/DSC_CertificateExport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_CertificateExport.Integration.Tests.ps1
@@ -62,7 +62,7 @@ try
         AfterAll {
             # Cleanup
             $validCertificate = Get-Item -Path "cert:\LocalMachine\My\$($script:validCertificateThumbprint)"
-            $null = Remove-Item -Path $validCertificate.PSPath -Force -ErrorAction SilentlyContinue
+            $null = Remove-Item -Path $validCertificate.PSPath -Force -ErrorAction SilentlyContinue -Confirm:$False
             $null = Remove-Item -Path $script:pfxPath -Force -ErrorAction SilentlyContinue
             $null = Remove-Item -Path $script:certificatePath -Force -ErrorAction SilentlyContinue
         }

--- a/tests/Integration/DSC_CertificateExport.Integration.Tests.ps1
+++ b/tests/Integration/DSC_CertificateExport.Integration.Tests.ps1
@@ -62,7 +62,7 @@ try
         AfterAll {
             # Cleanup
             $validCertificate = Get-Item -Path "cert:\LocalMachine\My\$($script:validCertificateThumbprint)"
-            $null = Remove-Item -Path $validCertificate.PSPath -Force -ErrorAction SilentlyContinue -Confirm:$False
+            $null = Remove-Item -Path $validCertificate.PSPath -Force -ErrorAction SilentlyContinue
             $null = Remove-Item -Path $script:pfxPath -Force -ErrorAction SilentlyContinue
             $null = Remove-Item -Path $script:certificatePath -Force -ErrorAction SilentlyContinue
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Importing PFX certificates to the local machine certificate path and the resource uses the function 'Import-PfxCertificateEx' from the common module results in the private key being installed in the users key store location rather than the machine path. The result of using the native 'Import-PfxCertificate' cmdlet is that the private key is stored in the same path as the public key import location.

#### This Pull Request (PR) fixes the following issues
    - Fixes #248

#### Task list
- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/certificatedsc/249)
<!-- Reviewable:end -->
