### PR TITLE
PfxImport: Add empty string password to .Import method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated build to use `Sampler.GitHubTasks` - Fixes [Issue #254](https://github.com/dsccommunity/CertificateDsc/issues/254).
 - Corrected changelog.
 - Updated pipeline tasks to latest pattern.
+- Passed in an empty string to X509Certificate2.Import so that we do not get MethodCountCouldNotFindBest exception when using a null 
+  password for the PFX certificate.
 
 ## [5.1.0] - 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected changelog.
 - Updated pipeline tasks to latest pattern.
 - Passed in an empty string to X509Certificate2.Import so that we do not get MethodCountCouldNotFindBest exception when using a null 
-  password for the PFX certificate.
+  password for the PFX certificate. Fixes [Issue #258](https://github.com/dsccommunity/CertificateDsc/issues/258)
 
 ## [5.1.0] - 2021-02-26
 

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -1082,7 +1082,7 @@ function Import-PfxCertificateEx
     }
     else
     {
-        $cert.Import($importDataValue, $flags)
+        $cert.Import($importDataValue, "", $flags)
     }
 
     $certStore = New-Object `


### PR DESCRIPTION
#### Pull Request (PR) description
Add an empty string to the X509Certificate2.Import to prevent the MethodCountCouldNotFindBest exception when using a null password to import the PFX certificate.

#### This Pull Request (PR) fixes the following issues
    - Fixes #258 

#### Task list
- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
