### PR TITLE
CertReq: Expired Certificate Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   images - Fixes [Issue #262](https://github.com/dsccommunity/CertificateDsc/issues/262).
 - Updated pipeline unit tests and integration tests to use Windows Server 2019 and
   Windows Server 2022 images - Fixes [Issue #262](https://github.com/dsccommunity/CertificateDsc/issues/262).
+- Adds logic to exclude certificates which have _already expired_ from being included in the array of 
+  certificates returned from the certificate store, when building a certificate request to be submitted to the PKI.
 
 ### Fixed
 

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -416,14 +416,15 @@ function Set-TargetResource
         $Subject = "CN=$Subject"
     } # if
 
-    # If we should look for renewals, check for existing certs
+    # If we should look for renewals, check for existing, non-expired certs
     if ($AutoRenew)
     {
         $certs = Get-ChildItem -Path Cert:\LocalMachine\My |
             Where-Object -FilterScript {
                 $_.Subject -eq $Subject -and `
                 (Compare-CertificateIssuer -Issuer $_.Issuer -CARootName $CARootName) -and `
-                    $_.NotAfter -lt (Get-Date).AddDays(30)
+                $_.NotAfter -gt (Get-Date) -and `
+                $_.NotAfter -lt (Get-Date).AddDays(30)
             }
 
         # If multiple certs have the same subject and were issued by the CA and are 30 days from expiration, return the newest


### PR DESCRIPTION
#### Pull Request (PR) description

Adds logic to exclude certificates which have _already expired_ from being included in the array of certificates returned from the certificate store, when building a certificate request to be submitted to the PKI.

If the certificate request attempts to perform renewal on a certificate that has already expired, the certificate request will be denied by the Certification Authority with an error: `Certificate not issued (Denied) Error Verifying Request Signature or Signing Certificate  A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file.`.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
