### PR TITLE
BREAKING CHANGE: CertReq: Improve certificate match selectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - CertReq:
-  - Made Certificate FriendlyName a mandatory parameter (key) so multiple certificates with same issuer and subject can be configured in the same DSC configuration - Fixes [Issue #269](https://github.com/dsccommunity/CertificateDsc/issues/269)
-  - Prevent certificates with differing FriendlyName and Template being considered as existing desired certificates - Fixes [Issue #121](https://github.com/dsccommunity/CertificateDsc/issues/121)
+  - Made Certificate FriendlyName a mandatory parameter - Fixes [Issue #269](https://github.com/dsccommunity/CertificateDsc/issues/269).
+  - Consider FriendlyName and Template when retrieving existing certs - Fixes [Issue #121](https://github.com/dsccommunity/CertificateDsc/issues/121).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - CertReq:
-  - Made Certificate FriendlyName a mandatory parameter - Fixes [Issue #269](https://github.com/dsccommunity/CertificateDsc/issues/269).
-  - Consider FriendlyName and Template when retrieving existing certs - Fixes [Issue #121](https://github.com/dsccommunity/CertificateDsc/issues/121).
+  - BREAKING CHANGE: Made Certificate FriendlyName a mandatory parameter - Fixes [Issue #269](https://github.com/dsccommunity/CertificateDsc/issues/269).
+  - Consider FriendlyName + Template when getting existing certs - Fixes [Issue #121](https://github.com/dsccommunity/CertificateDsc/issues/121).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CertReq:
+  - Made Certificate FriendlyName a mandatory parameter (key) so multiple certificates with same issuer and subject can be configured in the same DSC configuration - Fixes [Issue #269](https://github.com/dsccommunity/CertificateDsc/issues/269)
+  - Prevent certificates with differing FriendlyName and Template being considered as existing desired certificates - Fixes [Issue #121](https://github.com/dsccommunity/CertificateDsc/issues/121)
+
 ### Changed
 
 - Added support for publishing code coverage to `CodeCov.io` and

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -3,7 +3,7 @@
         AddToPath  = $true
         Target     = 'output\RequiredModules'
         Parameters = @{
-            Repository = ''
+            Repository = 'PSGallery'
         }
     }
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -22,5 +22,4 @@
     'DscResource.Common'        = 'latest'
     xDscResourceDesigner        = 'latest'
     xWebAdministration          = '3.1.1'
-    PSWSMan                     = 'latest'
 }

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -3,7 +3,7 @@
         AddToPath  = $true
         Target     = 'output\RequiredModules'
         Parameters = @{
-            Repository = 'PSGallery'
+            Repository = ''
         }
     }
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -22,4 +22,5 @@
     'DscResource.Common'        = 'latest'
     xDscResourceDesigner        = 'latest'
     xWebAdministration          = '3.1.1'
+    PSWSMan                     = 'latest'
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
       - job: Package_Module
         displayName: 'Package Module'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: 'windows-latest'
         steps:
           - pwsh: |
               dotnet tool install --global GitVersion.Tool

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ stages:
       - job: Package_Module
         displayName: 'Package Module'
         pool:
+          # Fails on 'ubuntu-latest' as libmi shared object library not available
           vmImage: 'windows-latest'
         steps:
           - pwsh: |

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -188,7 +188,7 @@ function Get-TargetResource
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($script:localizedData.GettingCertReqStatusMessage -f $Subject, $CA)
+            $($script:localizedData.GettingCertReqStatusMessage -f $Subject, $CA, $FriendlyName, $CertificateTemplate)
         ) -join '' )
 
     # If the Subject does not contain a full X500 path, construct just the CN
@@ -214,7 +214,7 @@ function Get-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($script:localizedData.CertificateExistsMessage -f $Subject, $ca, $cert.Thumbprint)
+                $($script:localizedData.CertificateExistsMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate, $certificate.Thumbprint)
             ) -join '' )
 
         $returnValue = @{
@@ -409,7 +409,7 @@ function Set-TargetResource
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($script:localizedData.StartingCertReqMessage -f $Subject, $ca)
+            $($script:localizedData.StartingCertReqMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate)
         ) -join '' )
 
     # If the Subject does not contain a full X500 path, construct just the CN
@@ -873,7 +873,7 @@ function Test-TargetResource
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($script:localizedData.TestingCertReqStatusMessage -f $Subject, $ca)
+            $($script:localizedData.TestingCertReqStatusMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate)
         ) -join '' )
 
     $filterScript = {
@@ -904,7 +904,7 @@ function Test-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($script:localizedData.CertificateExistsMessage -f $Subject, $ca, $certificate.Thumbprint)
+                $($script:localizedData.CertificateExistsMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate, $certificate.Thumbprint)
             ) -join '' )
 
         if ($AutoRenew)
@@ -914,7 +914,7 @@ function Test-TargetResource
                 # The certificate was found but it is expiring within 30 days or has expired
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.ExpiringCertificateMessage -f $Subject, $ca, $certificate.Thumbprint)
+                        $($script:localizedData.ExpiringCertificateMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate ,$certificate.Thumbprint)
                     ) -join '' )
                 return $false
             } # if
@@ -926,7 +926,7 @@ function Test-TargetResource
                 # The certificate has expired
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.ExpiredCertificateMessage -f $Subject, $ca, $certificate.Thumbprint)
+                        $($script:localizedData.ExpiredCertificateMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate ,$certificate.Thumbprint)
                     ) -join '' )
                 return $false
             } # if
@@ -981,7 +981,7 @@ function Test-TargetResource
         {
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.CertTemplateMismatch -f $Subject, $ca, $certificate.Thumbprint, $currentCertificateTemplateName)
+                    $($script:localizedData.CertTemplateMismatch -f $Subject, $ca, $certificate.FriendlyName, $certificate.Thumbprint, $currentCertificateTemplateName)
                 ) -join '' )
             return $false
         } # if
@@ -991,7 +991,7 @@ function Test-TargetResource
         {
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.CertFriendlyNameMismatch -f $Subject, $ca, $certificate.Thumbprint, $certificate.FriendlyName)
+                    $($script:localizedData.CertFriendlyNameMismatch -f $Subject, $ca, $currentCertificateTemplateName, $certificate.Thumbprint, $certificate.FriendlyName)
                 ) -join '' )
             return $false
         } # if
@@ -999,7 +999,7 @@ function Test-TargetResource
         # The certificate was found and is OK - so no change required.
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($script:localizedData.ValidCertificateExistsMessage -f $Subject, $ca, $certificate.Thumbprint)
+                $($script:localizedData.ValidCertificateExistsMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate, $certificate.Thumbprint)
             ) -join '' )
         return $true
     } # if
@@ -1007,7 +1007,7 @@ function Test-TargetResource
     # A valid certificate was not found
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($script:localizedData.NoValidCertificateMessage -f $Subject, $ca)
+            $($script:localizedData.NoValidCertificateMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate)
         ) -join '' )
     return $false
 } # end function Test-TargetResource

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -197,14 +197,15 @@ function Get-TargetResource
         $Subject = "CN=$Subject"
     } # if
 
-    $cert = Get-ChildItem -Path Cert:\LocalMachine\My |
+    $certs = Get-ChildItem -Path Cert:\LocalMachine\My |
         Where-Object -FilterScript {
-            $_.Subject -eq $Subject -and `
-            (Compare-CertificateIssuer -Issuer $_.Issuer -CARootName $CARootName)
+            $_.Subject -eq $Subject -and
+            (Compare-CertificateIssuer -Issuer $_.Issuer -CARootName $CARootName) -and
+            $_.FriendlyName -eq $FriendlyName
         }
 
-    # If multiple certs have the same subject and were issued by the CA, return the newest
-    $cert = $cert |
+    # If multiple certs have the same subject, issuer, friendly name and template, return the newest
+    $cert = $certs |
         Sort-Object -Property NotBefore -Descending |
             Select-Object -First 1
 

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -204,8 +204,18 @@ function Get-TargetResource
             $_.FriendlyName -eq $FriendlyName
         }
 
+    $matchedCerts = @()
+    foreach ($cert in $certs)
+    {
+            $cTemplate = ( $cert.Extensions | Where-Object{ $_.oid.Friendlyname -match 'Certificate Template Information' }).Format($false)
+            if ($cTemplate -match "${CertificateTemplate}.*")
+            {
+                    $matchedCerts += $cert
+            }
+    }
+
     # If multiple certs have the same subject, issuer, friendly name and template, return the newest
-    $cert = $certs |
+    $cert = $matchedCerts |
         Sort-Object -Property NotBefore -Descending |
             Select-Object -First 1
 

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -977,15 +977,6 @@ function Test-TargetResource
 
         $currentCertificateTemplateName = Get-CertificateTemplateName -Certificate $certificate
 
-        if ($CertificateTemplate -ne $currentCertificateTemplateName)
-        {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.CertTemplateMismatch -f $Subject, $ca, $certificate.FriendlyName, $certificate.Thumbprint, $currentCertificateTemplateName)
-                ) -join '' )
-            return $false
-        } # if
-
         # Check the friendly name of the certificate matches
         if ($FriendlyName -ne $certificate.FriendlyName)
         {

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -966,12 +966,20 @@ function Test-TargetResource
             if ($currentDns.Count -eq 0)
             {
                 # There are no current DNS SANs and there should be
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($script:localizedData.NoExistingSans -f $Subject, $ca, $FriendlyName, $CertificateTemplate, ($correctDns -join ',') ,$certificate.Thumbprint)
+                    ) -join '' )
                 return $false
             }
 
             if (@(Compare-Object -ReferenceObject $currentDns -DifferenceObject $correctDns).Count -gt 0)
             {
                 # Current DNS SANs and the desired DNS SANs do not match
+                Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.SansMismatch -f $Subject, $ca, $FriendlyName, $CertificateTemplate,($currentDns -join ',') , ($correctDns -join ',') ,$certificate.Thumbprint)
+                ) -join '' )
                 return $false
             }
         }

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -158,7 +158,7 @@ function Get-TargetResource
         [System.Boolean]
         $UseMachineContext,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $FriendlyName,
@@ -379,7 +379,7 @@ function Set-TargetResource
         [System.Boolean]
         $UseMachineContext,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $FriendlyName,
@@ -837,7 +837,7 @@ function Test-TargetResource
         [System.Boolean]
         $UseMachineContext,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $FriendlyName,

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -948,10 +948,10 @@ function Test-TargetResource
             }
 
             # Find out what SANs are on the current cert
+            $currentDns = @()
             if ($certificate.Extensions.Count -gt 0)
             {
                 $currentSanList = Get-CertificateSubjectAlternativeNameList -Certificate $certificate
-                $currentDns = @()
 
                 foreach ($san in $currentSanList)
                 {
@@ -961,16 +961,17 @@ function Test-TargetResource
                         $currentDns += $san.split('=')[1]
                     }
                 }
-
-                # Do the cert's DNS SANs and the desired DNS SANs match?
-                if (@(Compare-Object -ReferenceObject $currentDns -DifferenceObject $correctDns).Count -gt 0)
-                {
-                    return $false
-                }
             }
-            else
+
+            if ($currentDns.Count -eq 0)
             {
-                # There are no SANs and there should be
+                # There are no current DNS SANs and there should be
+                return $false
+            }
+
+            if (@(Compare-Object -ReferenceObject $currentDns -DifferenceObject $correctDns).Count -gt 0)
+            {
+                # Current DNS SANs and the desired DNS SANs do not match
                 return $false
             }
         }

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1
@@ -673,7 +673,7 @@ CertificateTemplate = "$CertificateTemplate"
 
         if ($acceptRequest -match '0x')
         {
-            New-InvalidOperationException -Message ($script:localizedData.GenericErrorThrown -f ($acceptRequest | Out-String))
+            New-InvalidOperationException -Message ($script:localizedData.GenericError -f ($acceptRequest | Out-String))
         }
         else
         {
@@ -968,7 +968,7 @@ function Test-TargetResource
                 # There are no current DNS SANs and there should be
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.NoExistingSans -f $Subject, $ca, $FriendlyName, $CertificateTemplate, ($correctDns -join ',') ,$certificate.Thumbprint)
+                        $($script:localizedData.NoExistingSansMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate, ($correctDns -join ',') ,$certificate.Thumbprint)
                     ) -join '' )
                 return $false
             }
@@ -978,7 +978,7 @@ function Test-TargetResource
                 # Current DNS SANs and the desired DNS SANs do not match
                 Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.SansMismatch -f $Subject, $ca, $FriendlyName, $CertificateTemplate,($currentDns -join ',') , ($correctDns -join ',') ,$certificate.Thumbprint)
+                    $($script:localizedData.SansMismatchMessage -f $Subject, $ca, $FriendlyName, $CertificateTemplate,($currentDns -join ',') , ($correctDns -join ',') ,$certificate.Thumbprint)
                 ) -join '' )
                 return $false
             }
@@ -991,7 +991,7 @@ function Test-TargetResource
         {
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.CertFriendlyNameMismatch -f $Subject, $ca, $currentCertificateTemplateName, $certificate.Thumbprint, $certificate.FriendlyName)
+                    $($script:localizedData.CertFriendlyNameMismatchMessage -f $Subject, $ca, $currentCertificateTemplateName, $certificate.Thumbprint, $certificate.FriendlyName)
                 ) -join '' )
             return $false
         } # if
@@ -1042,7 +1042,7 @@ function Assert-ResourceProperty
     if ((($KeyType -eq 'RSA') -and ($KeyLength -notin '1024', '2048', '4096', '8192')) -or `
         (($KeyType -eq 'ECDH') -and ($KeyLength -notin '192', '224', '256', '384', '521')))
     {
-        New-InvalidArgumentException -Message (($script:localizedData.InvalidKeySize) -f $KeyLength, $KeyType) -ArgumentName 'KeyLength'
+        New-InvalidArgumentException -Message (($script:localizedData.InvalidKeySizeError) -f $KeyLength, $KeyType) -ArgumentName 'KeyLength'
     }
 }# end function Assert-ResourceProperty
 

--- a/source/DSCResources/DSC_CertReq/DSC_CertReq.schema.mof
+++ b/source/DSCResources/DSC_CertReq/DSC_CertReq.schema.mof
@@ -2,6 +2,7 @@
 class DSC_CertReq : OMI_BaseResource
 {
     [Key, Description("Provide the text string to use as the subject of the certificate.")] String Subject;
+    [Key, Description("Specifies a friendly name for the certificate.")] String FriendlyName;
     [Write, Description("The type of CA in use, Standalone/Enterprise.")] String CAType;
     [Write, Description("The FQDN of the Active Directory Certificate Authority on the local area network. Leave empty to automatically locate.")] String CAServerFQDN;
     [Write, Description("The name of the certificate authority, by default this will be in format domain-servername-ca. Leave empty to automatically locate.")] String CARootName;
@@ -17,7 +18,6 @@ class DSC_CertReq : OMI_BaseResource
     [Write, Description("The URL to the Certification Enrollment Policy Service.")] String CepURL;
     [Write, Description("The URL to the Certification Enrollment Service.")] String CesURL;
     [Write, Description("Indicates whether or not the flag -adminforcemachine will be used when requesting certificates. Necessary for certain templates like e.g. DomainControllerAuthentication")] Boolean UseMachineContext;
-    [Write, Description("Specifies a friendly name for the certificate.")] String FriendlyName;
     [Write, Description("Specifies if the key type should be RSA or ECDH, defaults to RSA."), ValueMap{"RSA","ECDH"}, Values{"RSA","ECDH"}] String KeyType;
     [Write, Description("Specifies if the request type should be CMC or PKCS10, deafults to CMC."), ValueMap{"CMC","PKCS10"},Values{"CMC","PKCS10"}] String RequestType;
 };

--- a/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
+++ b/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
@@ -14,6 +14,8 @@ ConvertFrom-StringData @'
     ExpiringCertificateMessage = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' is about to expire.
     NoValidCertificateMessage = No valid certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
     ExpiredCertificateMessage = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has expired: {4}.
+    NoExistingSans = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has no SANs, yet the following SANs are specified: {4}. Certificate has the Thumbprint '{5}'.
+    SansMismatch = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has the SANs '{4}', yet the following SANs are specified: {5}. Certificate has the Thumbprint '{6}'.
     ValidCertificateExistsMessage = Valid certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}': {4}
     CertificateReqNotFoundError = Certificate Request file '{0}' not found.
     CertificateCerNotFoundError = Certificate file '{0}' not found.

--- a/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
+++ b/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
@@ -1,6 +1,6 @@
 ConvertFrom-StringData @'
-    GettingCertReqStatusMessage = Getting Certificate with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
-    CertificateExistsMessage = Certificate with Subject '{0}' Issuer {1}, FriendlyName '{2}' and CertificateTemplate '{3}' found with Thumbprint '{4}'.
+    GettingCertReqStatusMessage = Getting Certificate with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
+    CertificateExistsMessage = Certificate with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' found with Thumbprint '{4}'.
     StartingCertReqMessage = Starting Certificate request with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
     CreateRequestCertificateMessage = Creating certificate request '{1}' from '{0}'.
     CreateRequestResultCertificateMessage = Create certificate request result: {0}
@@ -10,13 +10,13 @@ ConvertFrom-StringData @'
     AcceptingRequestCertificateMessage = Accepting certificate '{1}' issued by {0}.
     AcceptingRequestResultCertificateMessage = Accepting certificate result: {0}
     CleaningUpRequestFilesMessage = Cleaning up certificate request files '{0}'.
-    TestingCertReqStatusMessage = Testing Certificate with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
-    ExpiringCertificateMessage = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' is about to expire.
-    NoValidCertificateMessage = No valid certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
-    ExpiredCertificateMessage = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has expired: {4}.
-    NoExistingSans = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has no SANs, yet the following SANs are specified: {4}. Certificate has the Thumbprint '{5}'.
-    SansMismatch = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has the SANs '{4}', yet the following SANs are specified: {5}. Certificate has the Thumbprint '{6}'.
-    ValidCertificateExistsMessage = Valid certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}': {4}
+    TestingCertReqStatusMessage = Testing Certificate with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
+    ExpiringCertificateMessage = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' is about to expire.
+    NoValidCertificateMessage = No valid certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
+    ExpiredCertificateMessage = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has expired: {4}.
+    NoExistingSans = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has no SANs, yet the following SANs are specified: {4}. Certificate has the Thumbprint '{5}'.
+    SansMismatch = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has the SANs '{4}', yet the following SANs are specified: {5}. Certificate has the Thumbprint '{6}'.
+    ValidCertificateExistsMessage = Valid certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}': {4}
     CertificateReqNotFoundError = Certificate Request file '{0}' not found.
     CertificateCerNotFoundError = Certificate file '{0}' not found.
     CertReqOutNotFoundError = CertReq.exe output file '{0}' not found.

--- a/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
+++ b/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
@@ -1,7 +1,7 @@
 ConvertFrom-StringData @'
-    GettingCertReqStatusMessage = Getting Certificate with Subject '{0}' issued by {1}.
-    CertificateExistsMessage = Certificate with Subject '{0}' issued by {1} found with thumbprint '{2}'.
-    StartingCertReqMessage = Starting Certificate request with Subject '{0}' issued by {1}.
+    GettingCertReqStatusMessage = Getting Certificate with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
+    CertificateExistsMessage = Certificate with Subject '{0}' Issuer {1}, FriendlyName '{2}' and CertificateTemplate '{3}' found with Thumbprint '{4}'.
+    StartingCertReqMessage = Starting Certificate request with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
     CreateRequestCertificateMessage = Creating certificate request '{1}' from '{0}'.
     CreateRequestResultCertificateMessage = Create certificate request result: {0}
     SubmittingRequestCertificateMessage = Submitting certificate request '{0}' returning '{1}' issued by {2}.
@@ -10,16 +10,16 @@ ConvertFrom-StringData @'
     AcceptingRequestCertificateMessage = Accepting certificate '{1}' issued by {0}.
     AcceptingRequestResultCertificateMessage = Accepting certificate result: {0}
     CleaningUpRequestFilesMessage = Cleaning up certificate request files '{0}'.
-    TestingCertReqStatusMessage = Testing Certificate with Subject '{0}' issued by {1}.
-    ExpiringCertificateMessage = The certificate found with subject '{0}' issued by {1} with thumbprint '{2}' is about to expire.
-    NoValidCertificateMessage = No valid certificate found with subject '{0}' issued by {1}.
-    ExpiredCertificateMessage = The certificate found with subject '{0}' issued by {1} with thumbprint '{2}' has expired.
-    ValidCertificateExistsMessage = Valid certificate '{2}' found with subject '{0}' issued by {1}.
+    TestingCertReqStatusMessage = Testing Certificate with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
+    ExpiringCertificateMessage = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' is about to expire.
+    NoValidCertificateMessage = No valid certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
+    ExpiredCertificateMessage = The certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has expired: {4}.
+    ValidCertificateExistsMessage = Valid certificate found with Subject '{0}' Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}': {4}
     CertificateReqNotFoundError = Certificate Request file '{0}' not found.
     CertificateCerNotFoundError = Certificate file '{0}' not found.
     CertReqOutNotFoundError = CertReq.exe output file '{0}' not found.
-    CertTemplateMismatch = The certificate with subject '{0}' issued by '{1}' with thumbprint {2} has the wrong template {3}.
-    CertFriendlyNameMismatch = The certificate with subject '{0}' issued by '{1}' with thumbprint {2} has the wrong friendly name '{3}'.
+    CertTemplateMismatch = The certificate with Subject '{0}' Issuer '{1}', FriendlyName '{2}' with Thumbprint '{3}' has the wrong template: {4}.
+    CertFriendlyNameMismatch = The certificate with Subject '{0}', Issuer '{1}', CertificateTemplate '{2}' and Thumbprint '{3}' has the wrong friendly name: {4}.
     InvalidKeySize = The key length '{0}' specified is invalid for '{1}' key types.
     GenericErrorThrown = A Generic Error was thrown when accepting a Certificate. It threw the following Error message: {0}
 '@

--- a/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
+++ b/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
@@ -18,7 +18,6 @@ ConvertFrom-StringData @'
     CertificateReqNotFoundError = Certificate Request file '{0}' not found.
     CertificateCerNotFoundError = Certificate file '{0}' not found.
     CertReqOutNotFoundError = CertReq.exe output file '{0}' not found.
-    CertTemplateMismatch = The certificate with Subject '{0}' Issuer '{1}', FriendlyName '{2}' with Thumbprint '{3}' has the wrong template: {4}.
     CertFriendlyNameMismatch = The certificate with Subject '{0}', Issuer '{1}', CertificateTemplate '{2}' and Thumbprint '{3}' has the wrong friendly name: {4}.
     InvalidKeySize = The key length '{0}' specified is invalid for '{1}' key types.
     GenericErrorThrown = A Generic Error was thrown when accepting a Certificate. It threw the following Error message: {0}

--- a/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
+++ b/source/DSCResources/DSC_CertReq/en-US/DSC_CertReq.strings.psd1
@@ -14,13 +14,13 @@ ConvertFrom-StringData @'
     ExpiringCertificateMessage = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' is about to expire.
     NoValidCertificateMessage = No valid certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}'.
     ExpiredCertificateMessage = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has expired: {4}.
-    NoExistingSans = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has no SANs, yet the following SANs are specified: {4}. Certificate has the Thumbprint '{5}'.
-    SansMismatch = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has the SANs '{4}', yet the following SANs are specified: {5}. Certificate has the Thumbprint '{6}'.
+    NoExistingSansMessage = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has no SANs, yet the following SANs are specified: {4}. Certificate has the Thumbprint '{5}'.
+    SansMismatchMessage = The certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}' has the SANs '{4}', yet the following SANs are specified: {5}. Certificate has the Thumbprint '{6}'.
     ValidCertificateExistsMessage = Valid certificate found with Subject '{0}', Issuer '{1}', FriendlyName '{2}' and CertificateTemplate '{3}': {4}
     CertificateReqNotFoundError = Certificate Request file '{0}' not found.
     CertificateCerNotFoundError = Certificate file '{0}' not found.
     CertReqOutNotFoundError = CertReq.exe output file '{0}' not found.
-    CertFriendlyNameMismatch = The certificate with Subject '{0}', Issuer '{1}', CertificateTemplate '{2}' and Thumbprint '{3}' has the wrong friendly name: {4}.
-    InvalidKeySize = The key length '{0}' specified is invalid for '{1}' key types.
-    GenericErrorThrown = A Generic Error was thrown when accepting a Certificate. It threw the following Error message: {0}
+    CertFriendlyNameMismatchMessage = The certificate with Subject '{0}', Issuer '{1}', CertificateTemplate '{2}' and Thumbprint '{3}' has the wrong friendly name: {4}.
+    InvalidKeySizeError = The key length '{0}' specified is invalid for '{1}' key types.
+    GenericError = A Generic Error was thrown when accepting a Certificate. It threw the following Error message: {0}
 '@

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -1650,7 +1650,7 @@ OID = $oid
                     -Mockwith $mock_GetChildItem_validCertWithoutSubject
 
                 It 'Should return false' {
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $false
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeFalse
                 }
             }
 
@@ -1667,7 +1667,7 @@ OID = $oid
                     -ParameterFilter $pathCertLocalMachineMy_parameterFilter
 
                 It 'Should return false' {
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $false
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeFalse
                 }
             }
 
@@ -1685,7 +1685,7 @@ OID = $oid
                     -ParameterFilter $pathCertLocalMachineMy_parameterFilter
 
                 It 'Should return false' {
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $false
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeFalse
                 }
             }
 
@@ -1709,7 +1709,7 @@ OID = $oid
                     -MockWith $mock_getCertificateSan_subjectAltName
 
                 It 'Should return true' {
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $true
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeTrue
                 }
             }
 
@@ -1727,7 +1727,7 @@ OID = $oid
                     Mock -CommandName Get-CertificateSubjectAlternativeName `
                         -MockWith $mock_getCertificateSan_subjectAltName
 
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $false
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeFalse
                 }
             }
 
@@ -1747,7 +1747,7 @@ OID = $oid
                 Mock -CommandName Get-CertificateTemplateName `
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
-                Test-TargetResource @paramsAutoRenew -Verbose | Should -Be $false
+                Test-TargetResource @paramsAutoRenew -Verbose | Should -BeFalse
             }
 
             Context 'When a valid certificate already exists and X500 subjects are in a different order but match' {
@@ -1767,7 +1767,7 @@ OID = $oid
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return true' {
-                    Test-TargetResource @paramsSubjectDifferentOrder -Verbose | Should -Be $true
+                    Test-TargetResource @paramsSubjectDifferentOrder -Verbose | Should -BeTrue
                 }
             }
 
@@ -1788,7 +1788,7 @@ OID = $oid
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return true' {
-                    Test-TargetResource @paramsSubjectAltName -Verbose | Should -Be $true
+                    Test-TargetResource @paramsSubjectAltName -Verbose | Should -BeTrue
                 }
             }
 
@@ -1809,7 +1809,7 @@ OID = $oid
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return false' {
-                    Test-TargetResource @paramsSubjectAltName -Verbose | Should -Be $false
+                    Test-TargetResource @paramsSubjectAltName -Verbose | Should -BeFalse
                 }
             }
 
@@ -1829,7 +1829,7 @@ OID = $oid
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return false' {
-                    Test-TargetResource @paramsSubjectAltName -Verbose | Should -Be $false
+                    Test-TargetResource @paramsSubjectAltName -Verbose | Should -BeFalse
                 }
             }
 
@@ -1850,7 +1850,7 @@ OID = $oid
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return false' {
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $false
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeFalse
                 }
             }
 
@@ -1872,7 +1872,7 @@ OID = $oid
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return true' {
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $true
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeTrue
                 }
             }
 
@@ -1894,7 +1894,7 @@ OID = $oid
                     -MockWith $mock_getCertificateTemplateName_validNonDefaultCertificateTemplate
 
                 It 'Should return true' {
-                    Test-TargetResource @paramsNonDefaultCertificateTemplate -Verbose | Should -Be $true
+                    Test-TargetResource @paramsNonDefaultCertificateTemplate -Verbose | Should -BeTrue
                 }
             }
 
@@ -1916,7 +1916,7 @@ OID = $oid
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return true' {
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $true
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeTrue
                 }
             }
 
@@ -1931,7 +1931,7 @@ OID = $oid
                     Mock -CommandName Get-CertificateTemplateName `
                         -MockWith $mock_getCertificateTemplateName_invalidCertificateTemplate
 
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $false
+                    Test-TargetResource @paramsStandard -Verbose | Should -BeFalse
                 }
             }
 
@@ -1947,7 +1947,7 @@ OID = $oid
                     Mock -CommandName Get-CertificateSubjectAlternativeName `
                         -MockWith $mock_getCertificateSan_subjectAltName
 
-                    Test-TargetResource @paramsStandardDomainController -Verbose | Should -Be $true
+                    Test-TargetResource @paramsStandardDomainController -Verbose | Should -BeTrue
                 }
             }
 
@@ -1963,7 +1963,7 @@ OID = $oid
                     Mock -CommandName Get-CertificateSubjectAlternativeName `
                         -MockWith $mock_getCertificateSan_subjectAltName
 
-                    Test-TargetResource @paramsNonMatchingFriendlyNameDomainController -Verbose | Should -Be $false
+                    Test-TargetResource @paramsNonMatchingFriendlyNameDomainController -Verbose | Should -BeFalse
                 }
             }
 
@@ -1980,7 +1980,7 @@ OID = $oid
                     -ParameterFilter $pathCertLocalMachineMy_parameterFilter
 
                 It 'Should return false' {
-                    Test-TargetResource @paramsAutoDiscovery -Verbose | Should -Be $false
+                    Test-TargetResource @paramsAutoDiscovery -Verbose | Should -BeFalse
                 }
 
                 It 'Should execute the auto-discovery function' {
@@ -2026,7 +2026,7 @@ OID = $oid
                 It 'Should return a true' {
                     Compare-CertificateSubject `
                         -ReferenceSubject 'CN=TestSubject' `
-                        -DifferenceSubject 'CN=TestSubject' | Should -Be $true
+                        -DifferenceSubject 'CN=TestSubject' | Should -BeTrue
                 }
             }
 
@@ -2034,7 +2034,7 @@ OID = $oid
                 It 'Should return a false' {
                     Compare-CertificateSubject `
                         -ReferenceSubject 'CN=TestSubject' `
-                        -DifferenceSubject 'CN=SubjectTest' | Should -Be $false
+                        -DifferenceSubject 'CN=SubjectTest' | Should -BeFalse
                 }
             }
 
@@ -2042,7 +2042,7 @@ OID = $oid
                 It 'Should return a true' {
                     Compare-CertificateSubject `
                         -ReferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
-                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' | Should -Be $true
+                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' | Should -BeTrue
                 }
             }
 
@@ -2050,7 +2050,7 @@ OID = $oid
                 It 'Should return a true' {
                     Compare-CertificateSubject `
                         -ReferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
-                        -DifferenceSubject 'E=xyz@contoso.com, CN=xyz.contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' | Should -Be $true
+                        -DifferenceSubject 'E=xyz@contoso.com, CN=xyz.contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' | Should -BeTrue
                 }
             }
 
@@ -2058,7 +2058,7 @@ OID = $oid
                 It 'Should return a false' {
                     Compare-CertificateSubject `
                         -ReferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
-                        -DifferenceSubject 'CN=xyz.contoso.com, E=test@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' | Should -Be $false
+                        -DifferenceSubject 'CN=xyz.contoso.com, E=test@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' | Should -BeFalse
                 }
             }
 
@@ -2066,7 +2066,7 @@ OID = $oid
                 It 'Should return a false' {
                     Compare-CertificateSubject `
                         -ReferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
-                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -Be $false
+                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -BeFalse
                 }
             }
 
@@ -2074,7 +2074,7 @@ OID = $oid
                 It 'Should return a false' {
                     Compare-CertificateSubject `
                         -ReferenceSubject $null `
-                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -Be $false
+                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -BeFalse
                 }
             }
 
@@ -2082,7 +2082,7 @@ OID = $oid
                 It 'Should return a false' {
                     Compare-CertificateSubject `
                         -ReferenceSubject '' `
-                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -Be $false
+                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -BeFalse
                 }
             }
         }
@@ -2092,7 +2092,7 @@ OID = $oid
                 It 'Should return a true' {
                     Compare-CertificateIssuer `
                         -Issuer 'CN=xyz.contoso.com' `
-                        -CARootName 'xyz.contoso.com' | Should -Be $true
+                        -CARootName 'xyz.contoso.com' | Should -BeTrue
                 }
             }
 
@@ -2100,7 +2100,7 @@ OID = $oid
                 It 'Should return a true' {
                     Compare-CertificateIssuer `
                         -Issuer 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
-                        -CARootName 'xyz.contoso.com' | Should -Be $true
+                        -CARootName 'xyz.contoso.com' | Should -BeTrue
                 }
             }
 
@@ -2108,7 +2108,7 @@ OID = $oid
                 It 'Should return a false' {
                     Compare-CertificateIssuer `
                         -Issuer 'CN=abc.contoso.com' `
-                        -CARootName 'xyz.contoso.com' | Should -Be $false
+                        -CARootName 'xyz.contoso.com' | Should -BeFalse
                 }
             }
 
@@ -2116,7 +2116,7 @@ OID = $oid
                 It 'Should return a false' {
                     Compare-CertificateIssuer `
                         -Issuer 'CN=abc.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
-                        -CARootName 'xyz.contoso.com' | Should -Be $false
+                        -CARootName 'xyz.contoso.com' | Should -BeFalse
                 }
             }
         }

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -1626,7 +1626,7 @@ OID = $oid
                 Mock -CommandName CertReq.exe -ParameterFilter {@('-accept', '-m', '-q', $pathCertReqTestCer_parameterFilter)} -MockWith {'0x'}
 
                 $errorRecord = Get-InvalidOperationRecord `
-                    -Message ($LocalizedData.GenericErrorThrown -f '0x')
+                    -Message ($LocalizedData.GenericError -f '0x')
 
                 It 'Should Throw A New-InvalidOperationException' {
                     { Set-TargetResource @paramsAutoDiscovery -Verbose } | Should -Throw $errorRecord
@@ -1998,9 +1998,9 @@ OID = $oid
 
             Context 'When RSA key type and key length is invalid' {
                 $errorRecord = Get-InvalidArgumentRecord `
-                    -Message (($LocalizedData.InvalidKeySize) -f '384', 'RSA') -ArgumentName 'KeyLength'
+                    -Message (($LocalizedData.InvalidKeySizeError) -f '384', 'RSA') -ArgumentName 'KeyLength'
 
-                It 'Should not throw' {
+                It 'Should throw' {
                     { Assert-ResourceProperty @paramRsaInvalid -Verbose } | Should -Throw $errorRecord
                 }
             }
@@ -2013,9 +2013,9 @@ OID = $oid
 
             Context 'When ECDH key type and key length is invalid' {
                 $errorRecord = Get-InvalidArgumentRecord `
-                    -Message (($LocalizedData.InvalidKeySize) -f '2048', 'ECDH') -ArgumentName 'KeyLength'
+                    -Message (($LocalizedData.InvalidKeySizeError) -f '2048', 'ECDH') -ArgumentName 'KeyLength'
 
-                It 'Should not throw' {
+                It 'Should throw' {
                     { Assert-ResourceProperty @paramEcdhInvalid -Verbose } | Should -Throw $errorRecord
                 }
             }

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -1709,7 +1709,6 @@ OID = $oid
                 }
             }
 
-
             Context 'When a certificate exists but does not match the Certificate Template' {
                 It 'Should return false' {
                     Mock -CommandName Get-ChildItem `

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -773,7 +773,7 @@ OID = $oid
 
             Context 'Two valid certs with matching Subject and Issuer, one with desired friendly name and one with undesired friendly name' {
 
-                Mock -CommandName Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `te
+                Mock -CommandName Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                     -MockWith { $validCertUndesiredFriendlyName, $validCert }
 
                 $result = Get-TargetResource @paramsStandard -Verbose

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -59,6 +59,20 @@ try
         $friendlyName = "Test Certificate"
         $invalidFriendlyName = 'Invalid Certificate'
 
+        $certificateTemplateOid = New-Object -TypeName System.Security.Cryptography.Oid -Property @{
+            Value = '1.3.6.1.4.1.311.21.7'
+            FriendlyName = 'Certificate Template Information'
+        }
+
+        $certificateTemplateExtension = New-Object -TypeName PSObject -Property @{
+            Oid = $certificateTemplateOid
+            Critical = $false
+        }
+
+        Add-Member -InputObject $certificateTemplateExtension -MemberType ScriptMethod -Name Format -Force -Value {
+            return "Template=$certificateTemplate(1.3.6.1.4.1.311.21.8.9213924.8643542.5195926.6309572.11459053.244.10365877.8067662), Major VersionNumber=100, Minor Version Number=10"
+        }
+
         $validCert = New-Object -TypeName PSObject -Property @{
             Thumbprint   = $validThumbprint
             Subject      = "CN=$validSubject"
@@ -66,26 +80,40 @@ try
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
             FriendlyName = $friendlyName
+            Extensions   = $certificateTemplateExtension
+        }
+
+        Add-Member -InputObject $validCert -MemberType ScriptMethod -Name Verify -Value {
+            return $true
+        }
+
+        $nonDefaultCertificateTemplateExtension = New-Object -TypeName PSObject -Property @{
+            Oid = $certificateTemplateOid
+            Critical = $false
+        }
+
+        Add-Member -InputObject $nonDefaultCertificateTemplateExtension -MemberType ScriptMethod -Name Format -Force -Value {
+            return "Template=$nonDefaultCertificateTemplate(1.3.6.1.4.1.311.21.8.9213924.8643542.5195926.6309572.11459053.244.10365877.8067662), Major VersionNumber=100, Minor Version Number=10"
         }
 
         $validCertWithNonDefaultTemplate = New-Object -TypeName PSObject -Property @{
-            Thumbprint          = $validThumbprint
-            Subject             = "CN=$validSubject"
-            Issuer              = $validIssuer
-            NotBefore           = (Get-Date).AddDays(-30) # Issued on
-            NotAfter            = (Get-Date).AddDays(31) # Expires after
-            FriendlyName        = $friendlyName
-            CertificateTemplate = $nonDefaultCertificateTemplate
+            Thumbprint   = $validThumbprint
+            Subject      = "CN=$validSubject"
+            Issuer       = $validIssuer
+            NotBefore    = (Get-Date).AddDays(-30) # Issued on
+            NotAfter     = (Get-Date).AddDays(31) # Expires after
+            Extensions   = @($nonDefaultCertificateTemplateExtension)
+            FriendlyName = $friendlyName
         }
 
         $validCertUndesiredTemplate = New-Object -TypeName PSObject -Property @{
-            Thumbprint          = $validThumbprint
-            Subject             = "CN=$validSubject"
-            Issuer              = $validIssuer
-            NotBefore           = (Get-Date).AddDays(-1) # Issued on
-            NotAfter            = (Get-Date).AddDays(31) # Expires after
-            FriendlyName        = $friendlyName
-            CertificateTemplate = $certificateTemplate
+            Thumbprint   = $validThumbprint
+            Subject      = "CN=$validSubject"
+            Issuer       = $validIssuer
+            NotBefore    = (Get-Date).AddDays(-1) # Issued on
+            NotAfter     = (Get-Date).AddDays(31) # Expires after
+            Extensions   = @($certificateTemplateExtension)
+            FriendlyName = $friendlyName
         }
 
         $validCertWithoutSubject = New-Object -TypeName PSObject -Property @{
@@ -94,6 +122,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
+            Extensions   = @($certificateTemplateExtension)
             FriendlyName = $friendlyName
         }
 
@@ -103,6 +132,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-1) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
+            Extensions   = @($certificateTemplateExtension)
             FriendlyName = $friendlyName + ' 2'
         }
 
@@ -112,6 +142,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-1) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
+            Extensions   = @($certificateTemplateExtension)
         }
 
         $invalidCert = New-Object -TypeName PSObject -Property @{
@@ -123,16 +154,13 @@ try
             FriendlyName = $invalidFriendlyName
         }
 
-        Add-Member -InputObject $validCert -MemberType ScriptMethod -Name Verify -Value {
-            return $true
-        }
-
         $expiringCert = New-Object -TypeName PSObject -Property @{
             Thumbprint   = $validThumbprint
             Subject      = "CN=$validSubject"
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(30) # Expires after
+            Extensions   = @($certificateTemplateExtension)
             FriendlyName = $friendlyName
         }
 
@@ -146,6 +174,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(-1) # Expires after
+            Extensions   = @($certificateTemplateExtension)
             FriendlyName = $friendlyName
         }
         Add-Member -InputObject $expiredCert -MemberType ScriptMethod -Name Verify -Value {
@@ -167,6 +196,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
+            Extensions   = @($certificateTemplateExtension)
             FriendlyName = $friendlyName
         }
         Add-Member -InputObject $validCertSubjectDifferentOrder -MemberType ScriptMethod -Name Verify -Value {
@@ -179,7 +209,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
-            Extensions   = @($sanExt)
+            Extensions   = @($sanExt,$certificateTemplateExtension)
             FriendlyName = $friendlyName
         }
         Add-Member -InputObject $validSANCert -MemberType ScriptMethod -Name Verify -Value {
@@ -200,7 +230,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
-            Extensions   = @($incorrectSanExt)
+            Extensions   = @($incorrectSanExt,$certificateTemplateExtension)
             FriendlyName = $friendlyName
         }
         Add-Member -InputObject $incorrectSANCert -MemberType ScriptMethod -Name Verify -Value {
@@ -213,7 +243,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
-            Extensions   = @()
+            Extensions   = @($certificateTemplateExtension)
             FriendlyName = $friendlyName
         }
         Add-Member -InputObject $emptySANCert -MemberType ScriptMethod -Name Verify -Value {
@@ -226,6 +256,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
+            Extensions   = @($certificateTemplateExtension)
             FriendlyName = 'This name will not match'
         }
         Add-Member -InputObject $incorrectFriendlyName -MemberType ScriptMethod -Name Verify -Value {

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -716,10 +716,10 @@ OID = $oid
                 }
             }
 
-            Mock -CommandName Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
-                -MockWith { $validCertUndesiredFriendlyName, $validCert }
-
             Context 'Two valid certs with matching Subject and Issuer, one with desired friendly name and one with undesired friendly name' {
+
+                Mock -CommandName Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                    -MockWith { $validCertUndesiredFriendlyName, $validCert }
 
                 $result = Get-TargetResource @paramsStandard -Verbose
 
@@ -742,10 +742,10 @@ OID = $oid
                 }
             }
 
-            Mock -CommandName Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
-            -MockWith { $validCertEmptyFriendlyName, $validCert }
-
             Context 'Two valid certs with matching Subject and Issuer, one with desired friendly name and one with no friendly name' {
+
+                Mock -CommandName Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                    -MockWith { $validCertEmptyFriendlyName, $validCert }
 
                 $result = Get-TargetResource @paramsStandard -Verbose
 

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -1871,9 +1871,6 @@ OID = $oid
                 Mock -CommandName Get-CertificateTemplateName `
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
-                # Mock -CommandName Get-CertificateSubjectAlternativeName `
-                #     -MockWith $mock_getCertificateSan_subjectAltName
-
                 It 'Should return true' {
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $true
                 }
@@ -1896,9 +1893,6 @@ OID = $oid
                 Mock -CommandName Get-CertificateTemplateName `
                     -MockWith $mock_getCertificateTemplateName_validNonDefaultCertificateTemplate
 
-                # Mock -CommandName Get-CertificateSubjectAlternativeName `
-                #     -MockWith $mock_getCertificateSan_subjectAltName
-
                 It 'Should return true' {
                     Test-TargetResource @paramsNonDefaultCertificateTemplate -Verbose | Should -Be $true
                 }
@@ -1920,9 +1914,6 @@ OID = $oid
 
                 Mock -CommandName Get-CertificateTemplateName `
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
-
-                # Mock -CommandName Get-CertificateSubjectAlternativeName `
-                #     -MockWith $mock_getCertificateSan_subjectAltName
 
                 It 'Should return true' {
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $true

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -305,6 +305,22 @@ try
             KeyType             = 'RSA'
         }
 
+        $paramsNonDefaultCertificateTemplate = @{
+            Subject             = $validSubject
+            CAServerFQDN        = $caServerFQDN
+            CARootName          = $caRootName
+            KeyLength           = $keyLength
+            Exportable          = $exportable
+            ProviderName        = $providerName
+            OID                 = $oid
+            KeyUsage            = $keyUsage
+            CertificateTemplate = $nonDefaultCertificateTemplate
+            Credential          = $testCredential
+            AutoRenew           = $false
+            FriendlyName        = $friendlyName
+            KeyType             = 'RSA'
+        }
+
         $paramsStandardProviderNameWithQuotes = @{
             Subject             = $validSubject
             CAServerFQDN        = $caServerFQDN

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -1839,7 +1839,6 @@ OID = $oid
                 }
             }
 
-            ##### DJC
             Context 'When two valid certs exist matching Subject and Issuer, one with desired friendly name and one with undesired friendly name' {
 
                 Mock -CommandName Find-CertificateAuthority `
@@ -1915,7 +1914,6 @@ OID = $oid
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $true
                 }
             }
-            #####
 
             Context 'When a certificate exists but does not match the Certificate Template' {
                 It 'Should return false' {

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -817,7 +817,7 @@ OID = $oid
                 Mock -CommandName Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                     -MockWith { $validCertUndesiredTemplate, $validCertWithNonDefaultTemplate }
 
-                $result = Get-TargetResource @paramsStandard -Verbose
+                $result = Get-TargetResource @paramsNonDefaultCertificateTemplate -Verbose
 
                 It 'Should return a hashtable' {
                     $result | Should -BeOfType System.Collections.Hashtable

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -351,6 +351,21 @@ try
             FriendlyName        = $friendlyName
         }
 
+        $paramsNonMatchingFriendlyNameDomainController = @{
+            Subject             = $validSubject
+            CAServerFQDN        = $caServerFQDN
+            CARootName          = $caRootName
+            KeyLength           = $keyLength
+            Exportable          = $exportable
+            ProviderName        = $providerName
+            OID                 = $oid
+            KeyUsage            = $keyUsage
+            CertificateTemplate = $certificateDCTemplate
+            Credential          = $testCredential
+            AutoRenew           = $false
+            FriendlyName        = $friendlyName + ' 2'
+        }
+
         $paramsInvalid = @{
             Subject             = $invalidSubject
             CAServerFQDN        = $caServerFQDN
@@ -1943,6 +1958,22 @@ OID = $oid
                         -MockWith $mock_getCertificateSan_subjectAltName
 
                     Test-TargetResource @paramsStandardDomainController -Verbose | Should -Be $true
+                }
+            }
+
+            Context 'When a Domain Controller certificate template is used, A valid certificate already exists and has a non-matching FriendlyName' {
+                It 'Should return true' {
+                    Mock -CommandName Get-ChildItem `
+                        -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                        -Mockwith $mock_getChildItem_validCert
+
+                    Mock -CommandName Get-CertificateTemplateName `
+                        -MockWith $mock_getCertificateTemplateName_validDCCertificateTemplate
+
+                    Mock -CommandName Get-CertificateSubjectAlternativeName `
+                        -MockWith $mock_getCertificateSan_subjectAltName
+
+                    Test-TargetResource @paramsNonMatchingFriendlyNameDomainController -Verbose | Should -Be $false
                 }
             }
 

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -1886,7 +1886,7 @@ OID = $oid
                 #     -MockWith $mock_getCertificateSan_subjectAltName
 
                 It 'Should return true' {
-                    Test-TargetResource @paramsStandard -Verbose | Should -Be $true
+                    Test-TargetResource @paramsNonDefaultCertificateTemplate -Verbose | Should -Be $true
                 }
             }
 

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -1904,7 +1904,6 @@ OID = $oid
                 }
             }
 
-
             Context 'When two valid certs exist matching Subject and Issuer, one with desired friendly name and one without friendly name' {
 
                 Mock -CommandName Find-CertificateAuthority `

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -97,7 +97,7 @@ try
         }
 
         $validCertWithNonDefaultTemplate = New-Object -TypeName PSObject -Property @{
-            Thumbprint   = $validThumbprint
+            Thumbprint   = $validThumbprint + 2
             Subject      = "CN=$validSubject"
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
@@ -107,7 +107,7 @@ try
         }
 
         $validCertUndesiredTemplate = New-Object -TypeName PSObject -Property @{
-            Thumbprint   = $validThumbprint
+            Thumbprint   = $validThumbprint + 3
             Subject      = "CN=$validSubject"
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-1) # Issued on
@@ -127,7 +127,7 @@ try
         }
 
         $validCertUndesiredFriendlyName = New-Object -TypeName PSObject -Property @{
-            Thumbprint   = New-CertificateThumbprint -Fips
+            Thumbprint   = $validThumbprint + 5
             Subject      = "CN=$validSubject"
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-1) # Issued on
@@ -137,7 +137,7 @@ try
         }
 
         $validCertWithoutFriendlyName = New-Object -TypeName PSObject -Property @{
-            Thumbprint   = New-CertificateThumbprint -Fips
+            Thumbprint   = $validThumbprint + 6
             Subject      = "CN=$validSubject"
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-1) # Issued on

--- a/tests/Unit/DSC_CertReq.Tests.ps1
+++ b/tests/Unit/DSC_CertReq.Tests.ps1
@@ -298,7 +298,6 @@ try
             ProviderName        = $providerName
             OID                 = $oid
             KeyUsage            = $keyUsage
-            CertificateTemplate = $certificateTemplate
             Credential          = $testCredential
             AutoRenew           = $false
             FriendlyName        = $friendlyName


### PR DESCRIPTION
#### Pull Request (PR) description

*Breaking Change*: Support multiple certificates with the same `issuer` and `subject` by making `friendlyName` a mandatory (key) parameter

Prevent existing certificates with non-matching `friendlyName` and `template` being considered as existing desired certificates; This resolves problems where an incorrect existing certificate is compared with the desired state and `Test-TargetResource` consequentially returns `$false`.

#### This Pull Request (PR) fixes the following issues

- Fixes #121
- Fixes #269

- Replaces PR #206 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/certificatedsc/271)
<!-- Reviewable:end -->
